### PR TITLE
ci: set the correct labels for github runner

### DIFF
--- a/.github/workflows/test-examples-self-hosted.yml
+++ b/.github/workflows/test-examples-self-hosted.yml
@@ -15,7 +15,7 @@ jobs:
   run-all-examples:
     name: Run all examples in SGX and CVM mode
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: self-hosted
+    runs-on: [self-hosted, sgx-cvm-sim]
     container:
       image: registry.scontain.com/workshop/scone
       credentials:


### PR DESCRIPTION
This PR addresses a fix to unlock the CI 

## What's included
Runner labels are changed so the task can be executed