### PR TITLE
fix(demos): pin runtime version in Apply sections and hello-world

### DIFF
--- a/configmap/scone.template.yaml
+++ b/configmap/scone.template.yaml
@@ -38,6 +38,7 @@ spec:
   spol: true
   cvm: ${CVM_MODE}
   scone_enclave: ${SCONE_ENCLAVE}
+  version: ${SCONE_RUNTIME_VERSION}
   access_policy:
     read:
       - ANY

--- a/docs/hello-world.sh
+++ b/docs/hello-world.sh
@@ -421,7 +421,7 @@ pe "$(cat <<'EOF'
 EOF
 )"
 pe "$(cat <<'EOF'
-scone-td-build apply -f manifest.job.yaml -c ${CAS_NAME}.${CAS_NAMESPACE} -p -s ./storage.json --manifest-env SCONE_SYSLIBS=1 --manifest-env SCONE_PRODUCTION=0 --spol --manifest-env SCONE_VERSION=1 --output-manifest-file manifest.job.sanitized.yaml ${CVM_MODE} ${SCONE_ENCLAVE}
+scone-td-build apply -f manifest.job.yaml -c ${CAS_NAME}.${CAS_NAMESPACE} -p -s ./storage.json --manifest-env SCONE_SYSLIBS=1 --manifest-env SCONE_PRODUCTION=0 --spol --manifest-env SCONE_VERSION=1 --output-manifest-file manifest.job.sanitized.yaml --version ${SCONE_RUNTIME_VERSION} ${CVM_MODE} ${SCONE_ENCLAVE}
 EOF
 )"
 

--- a/flask-redis-netshield/scone.template.yaml
+++ b/flask-redis-netshield/scone.template.yaml
@@ -59,6 +59,7 @@ spec:
   spol: true
   cvm: ${CVM_MODE}
   scone_enclave: ${SCONE_ENCLAVE}
+  version: ${SCONE_RUNTIME_VERSION}
   access_policy:
     read:
       - ANY

--- a/flask-redis/scone.template.yaml
+++ b/flask-redis/scone.template.yaml
@@ -59,6 +59,7 @@ spec:
   spol: true
   cvm: ${CVM_MODE}
   scone_enclave: ${SCONE_ENCLAVE}
+  version: ${SCONE_RUNTIME_VERSION}
   access_policy:
     read:
       - ANY

--- a/hello-world/README.md
+++ b/hello-world/README.md
@@ -154,7 +154,7 @@ Convert the native manifest into a sanitized confidential manifest:
 
 ```bash
 # Convert the native manifest into a confidential manifest.
-scone-td-build apply -f manifest.job.yaml -c ${CAS_NAME}.${CAS_NAMESPACE} -p -s ./storage.json --manifest-env SCONE_SYSLIBS=1 --manifest-env SCONE_PRODUCTION=0 --spol --manifest-env SCONE_VERSION=1 --output-manifest-file manifest.job.sanitized.yaml ${CVM_MODE} ${SCONE_ENCLAVE}
+scone-td-build apply -f manifest.job.yaml -c ${CAS_NAME}.${CAS_NAMESPACE} -p -s ./storage.json --manifest-env SCONE_SYSLIBS=1 --manifest-env SCONE_PRODUCTION=0 --spol --manifest-env SCONE_VERSION=1 --output-manifest-file manifest.job.sanitized.yaml --version ${SCONE_RUNTIME_VERSION} ${CVM_MODE} ${SCONE_ENCLAVE}
 ```
 
 ## 9. Deploy the Confidential Manifest

--- a/network-policy/scone.template.yaml
+++ b/network-policy/scone.template.yaml
@@ -54,6 +54,7 @@ spec:
   spol: true
   cvm: ${CVM_MODE}
   scone_enclave: ${SCONE_ENCLAVE}
+  version: ${SCONE_RUNTIME_VERSION}
   access_policy:
     read:
       - ANY

--- a/scripts/hello-world.sh
+++ b/scripts/hello-world.sh
@@ -335,11 +335,11 @@ printf "${RESET}"
 
 printf "${ORANGE}"
 printf '%s\n' '# Convert the native manifest into a confidential manifest.'
-printf '%s\n' 'scone-td-build apply -f manifest.job.yaml -c ${CAS_NAME}.${CAS_NAMESPACE} -p -s ./storage.json --manifest-env SCONE_SYSLIBS=1 --manifest-env SCONE_PRODUCTION=0 --spol --manifest-env SCONE_VERSION=1 --output-manifest-file manifest.job.sanitized.yaml ${CVM_MODE} ${SCONE_ENCLAVE}'
+printf '%s\n' 'scone-td-build apply -f manifest.job.yaml -c ${CAS_NAME}.${CAS_NAMESPACE} -p -s ./storage.json --manifest-env SCONE_SYSLIBS=1 --manifest-env SCONE_PRODUCTION=0 --spol --manifest-env SCONE_VERSION=1 --output-manifest-file manifest.job.sanitized.yaml --version ${SCONE_RUNTIME_VERSION} ${CVM_MODE} ${SCONE_ENCLAVE}'
 printf "${RESET}"
 
 # Convert the native manifest into a confidential manifest.
-scone-td-build apply -f manifest.job.yaml -c ${CAS_NAME}.${CAS_NAMESPACE} -p -s ./storage.json --manifest-env SCONE_SYSLIBS=1 --manifest-env SCONE_PRODUCTION=0 --spol --manifest-env SCONE_VERSION=1 --output-manifest-file manifest.job.sanitized.yaml ${CVM_MODE} ${SCONE_ENCLAVE}
+scone-td-build apply -f manifest.job.yaml -c ${CAS_NAME}.${CAS_NAMESPACE} -p -s ./storage.json --manifest-env SCONE_SYSLIBS=1 --manifest-env SCONE_PRODUCTION=0 --spol --manifest-env SCONE_VERSION=1 --output-manifest-file manifest.job.sanitized.yaml --version ${SCONE_RUNTIME_VERSION} ${CVM_MODE} ${SCONE_ENCLAVE}
 
 printf "${VIOLET}"
 printf '%s\n' ''


### PR DESCRIPTION
## Summary

- Add `version: ${SCONE_RUNTIME_VERSION}` to the `Apply` spec in `configmap`, `flask-redis`, `flask-redis-netshield`, and `network-policy` templates so the sconified policy matches the runtime pinned in the corresponding `Register` spec instead of falling back to the default.
- Add `--version ${SCONE_RUNTIME_VERSION}` to the `scone-td-build apply` invocation in `hello-world/README.md` (and the extracted `scripts/hello-world.sh` / `docs/hello-world.sh`) so the CLI path behaves consistently with the other demos.

Discovered while running the `flask-redis` CVM demo on a Cloud&Heat SEV-SNP cluster: without the `version` field, `scone-td-build apply` silently used a different runtime than the one used for `Register`, which caused policy/image mismatches on real CVM hardware.

## Test plan

- [ ] Re-run `flask-redis` CVM demo end-to-end with `SCONE_RUNTIME_VERSION=6.1.0-rc.0` and confirm the produced session references the pinned runtime.
- [ ] Re-run `hello-world` SGX and CVM flows via the README and via `scripts/hello-world.sh` and confirm both paths pass the version through to `scone-td-build apply`.
- [ ] Spot-check `configmap`, `network-policy`, and `flask-redis-netshield` renderings to confirm the new `version` line resolves correctly.

Fixes #26