### PR TITLE
fix(flask-redis): use Alpine musl base so TLS works on SEV-SNP

### DIFF
--- a/flask-redis-netshield/Values.yaml
+++ b/flask-redis-netshield/Values.yaml
@@ -6,7 +6,7 @@ environment:
   CVM_MODE: 'false'
   SCONE_ENCLAVE: 'false'
   REGISTRY: registry.scontain.com
-  IMAGE_NAME: registry.scontain.com/k8s-scone-images/flask-redis:latest
+  IMAGE_NAME: registry.scontain.com/k8s-scone-images/flask-redis-netshield:latest
   NAMESPACE: scone-tools
   SIGNER: |-
     -----BEGIN PUBLIC KEY-----

--- a/flask-redis/Dockerfile
+++ b/flask-redis/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.11-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
Switches the flask-redis image base from `python:3.11-slim` (glibc) to `python:3.11-alpine` (musl). One line; app code, dependencies, and TLS certs are unchanged.

On AMD SEV-SNP, SCONE's musl runtime silently skips the glibc OpenSSL's in-enclave client handshake, so the sconified flask writes plaintext to the TLS-only Redis, gets reset, and crashloops. A musl base makes the handshake engage. Intel TDX and SGX were unaffected either way.

Verified on SEV-SNP: the full REST round-trip (`POST`/`GET /client/<id>`, `/keys`) returns 200.