### PR TITLE
Update demos for the renamed manifest fields and the apply -f flow

### DIFF
--- a/configmap/README.md
+++ b/configmap/README.md
@@ -36,8 +36,9 @@ Default values are stored in `Values.yaml`. `tplenv` asks whether to keep the de
 - `$SCONE_RUNTIME_VERSION` - SCONE version to use (for example, `6.1.0-rc.0`)
 - `$CAS_NAMESPACE` - CAS namespace (for example, `default`)
 - `$CAS_NAME` - CAS name (for example, `cas`)
-- `$CVM_MODE` - Set to `--cvm` for CVM mode, otherwise leave empty for SGX
-- `$SCONE_ENCLAVE` - In CVM mode, set to `--scone-enclave` for confidential nodes, or leave empty for Kata Pods
+- `$CAS_ENDPOINT` - Address the manifest targets; keep it in sync with `$CAS_NAME`.`$CAS_NAMESPACE` (default: `cas.default`), or set to an external CAS address to run against one
+- `$TEE_TYPE` - Set to `cvm` for CVM mode or `sgx` for SGX
+- `$SCONE_ENCLAVE` - In CVM mode, set to `true` for confidential nodes, or `false` for Kata Pods
 - `$NAMESPACE` - Kubernetes namespace where the demo runs (default: `default`)
 
 Set `SIGNER` for policy signing:
@@ -114,9 +115,9 @@ fi
 # Apply the Kubernetes manifest.
 kubectl apply -f manifests/manifest.yaml -n ${NAMESPACE}
 # Retry the wrapped command until it succeeds or reaches the retry limit.
-retry-spinner --retries 5 --wait 2 -- kubectl logs job/my-rust-app -n ${NAMESPACE} -c reader-1
+retry-spinner --retries 30 --wait 5 -- kubectl logs job/my-rust-app -n ${NAMESPACE} -c reader-1
 # Retry the wrapped command until it succeeds or reaches the retry limit.
-retry-spinner --retries 5 --wait 2 -- kubectl logs job/my-rust-app -n ${NAMESPACE} -c reader-2
+retry-spinner --retries 30 --wait 5 -- kubectl logs job/my-rust-app -n ${NAMESPACE} -c reader-2
 
 # Clean up native app
 # Delete the Kubernetes resource if it exists.
@@ -127,18 +128,19 @@ Your containers should print content from the mounted ConfigMap files.
 
 ## 8. Prepare and Apply the SCONE Manifest
 
-First, attest the CAS so the local SCONE CLI has the correct session encryption key. The kubectl path covers an in-cluster CAS; if it fails (typical when `${CAS_NAME}.${CAS_NAMESPACE}` resolves to an external CAS like `scone-cas.cf`), the second branch attests the public CAS directly.
+First, attest the CAS so the local SCONE CLI has the correct session encryption key. The kubectl path covers an in-cluster CAS; if it fails (typical when `${CAS_ENDPOINT}` points at an external CAS like `edge.scone-cas.cf`), the second branch attests the public CAS directly.
 
 ```bash
 # Attest the CAS instance before sending encrypted policies.
 kubectl scone cas attest --namespace ${CAS_NAMESPACE} ${CAS_NAME} -C -G -S \
-    || scone cas attest ${CAS_NAME}.${CAS_NAMESPACE} -C -G -S \
-        --only_for_testing-debug --only_for_testing-ignore-signer --only_for_testing-trust-any
+    || scone cas attest ${CAS_ENDPOINT} -C -G -S \
+        --only_for_testing-debug --only_for_testing-ignore-signer --only_for_testing-trust-any \
+    || echo "CAS attestation skipped: ${CAS_ENDPOINT} runs in simulation mode, so it cannot produce a DCAP quote"
 ```
 
 ```bash
 # Generate the confidential image and sanitized manifest from the SCONE configuration.
-scone-td-build from -y manifests/scone.yaml
+scone-td-build apply -f manifests/scone.yaml
 ```
 
 This command:
@@ -158,9 +160,9 @@ kubectl apply -f manifests/manifest.prod.sanitized.yaml -n ${NAMESPACE}
 
 ```bash
 # Retry the wrapped command until it succeeds or reaches the retry limit.
-retry-spinner -- kubectl logs job/my-rust-app -n ${NAMESPACE} -c reader-1 --follow
+retry-spinner --retries 30 --wait 5 -- kubectl logs job/my-rust-app -n ${NAMESPACE} -c reader-1 --follow
 # Retry the wrapped command until it succeeds or reaches the retry limit.
-retry-spinner -- kubectl logs job/my-rust-app -n ${NAMESPACE} -c reader-2 --follow
+retry-spinner --retries 30 --wait 5 -- kubectl logs job/my-rust-app -n ${NAMESPACE} -c reader-2 --follow
 ```
 
 ## 11. Clean Up

--- a/configmap/Values.yaml
+++ b/configmap/Values.yaml
@@ -1,11 +1,12 @@
 environment:
   DEMO_IMAGE: registry.scontain.com/k8s-scone-images/configmap:native
-  DESTINATION_IMAGE_NAME: registry.scontain.com/workshop/configmap:protected
+  DESTINATION_IMAGE_NAME: registry.scontain.com/k8s-scone-images/configmap:protected
   IMAGE_PULL_SECRET_NAME: sconeapps
   SCONE_RUNTIME_VERSION: 6.1.0-rc.0
   CAS_NAMESPACE: default
   CAS_NAME: cas
-  CVM_MODE: 'false'
+  CAS_ENDPOINT: cas.default
+  TEE_TYPE: sgx
   SCONE_ENCLAVE: 'false'
   REGISTRY: registry.scontain.com
   NAMESPACE: default

--- a/configmap/environment-variables.md
+++ b/configmap/environment-variables.md
@@ -7,10 +7,11 @@ This file defines the environment variables used to configure the `configmap` ex
 4. The SCONE version is stored in `${SCONE_RUNTIME_VERSION}`.
    The recommended value is `6.1.0-rc.0`.
 5. The CAS runs in Kubernetes namespace `${CAS_NAMESPACE}`.
-   The templates resolve `${CAS_NAME}.${CAS_NAMESPACE}` to the CAS endpoint, so for SCONE's public CAS at `scone-cas.cf` set `CAS_NAMESPACE=cf`.
+   `${CAS_NAME}` and `${CAS_NAMESPACE}` address the in-cluster CAS for `kubectl` calls.
 6. The CAS name is stored in `${CAS_NAME}`.
-   For SCONE's public CAS, set `CAS_NAME=scone-cas`.
-7. If you want to use CVM mode, set `${CVM_MODE}` to `true`. For SGX, set to `false`.
+   The manifests use `${CAS_ENDPOINT}` instead, which defaults to `cas.default`. Point it at
+   a public CAS to run against one, for example `CAS_ENDPOINT=edge.scone-cas.cf`.
+7. Set `${TEE_TYPE}` to `cvm` for CVM mode or `sgx` for SGX.
 8. In CVM mode, you can run on confidential Kubernetes nodes or Kata Pods.
    We recommend using confidential nodes and setting `${SCONE_ENCLAVE}` to `true`.
 9. Set the local signer key in `${SIGNER}`.

--- a/configmap/scone.template.yaml
+++ b/configmap/scone.template.yaml
@@ -3,14 +3,14 @@ kind: Register
 metadata:
   name: configmap-example
 spec:
-  protected_image: ${DEMO_IMAGE}
-  unprotected_image: ${DEMO_IMAGE}
-  destination_image: ${DESTINATION_IMAGE_NAME}
-  enforce: ["/usr/local/bin/folder-reader"]
-  push_scone_image: true
-  version: ${SCONE_RUNTIME_VERSION}
-  cvm: ${CVM_MODE}
-  manifest_env:
+  source-image: ${DEMO_IMAGE}
+  reference-image: ${DEMO_IMAGE}
+  output-image: ${DESTINATION_IMAGE_NAME}
+  protected-binaries: ["/usr/local/bin/folder-reader"]
+  push-image: true
+  scone-version: ${SCONE_RUNTIME_VERSION}
+  tee-type: ${TEE_TYPE}
+  container-env:
     - {name: SCONE_VERSION, value: "1"}
     - {name: SCONE_SYSLIBS, value: "1"}
     - {name: SCONE_PRODUCTION, value: "0"}
@@ -23,22 +23,22 @@ metadata:
 spec:
   file:
     - "manifests/manifest.yaml"
-  output_manifest_file: "manifests/manifest.prod.sanitized.yaml"
-  output_session_file: "manifests/manifest.prod.session.yaml"
-  cas_address:
-    address: ${CAS_NAME}.${CAS_NAMESPACE}
-  session_env:
+  output-manifest: "manifests/manifest.prod.sanitized.yaml"
+  output-session: "manifests/manifest.prod.session.yaml"
+  cas-endpoint:
+    address: ${CAS_ENDPOINT}
+  cas-policy-env:
     - {name: SCONE_VERSION, value: "1"}
-  manifest_env:
+  container-env:
     - {name: SCONE_VERSION, value: "1"}
     - {name: SCONE_SYSLIBS, value: "1"}
     - {name: SCONE_PRODUCTION, value: "0"}
     - {name: SCONE_HEAP, value: "2G"}
   permissive: true
-  spol: true
-  cvm: ${CVM_MODE}
-  scone_enclave: ${SCONE_ENCLAVE}
-  version: ${SCONE_RUNTIME_VERSION}
+  encrypted-cas-policy: false
+  tee-type: ${TEE_TYPE}
+  scone-enclave: ${SCONE_ENCLAVE}
+  scone-version: ${SCONE_RUNTIME_VERSION}
   access_policy:
     read:
       - ANY

--- a/docs/configmap.sh
+++ b/docs/configmap.sh
@@ -164,8 +164,9 @@ printf '%s\n' '- `$IMAGE_PULL_SECRET_NAME` - Pull secret name (default: `sconeap
 printf '%s\n' '- `$SCONE_RUNTIME_VERSION` - SCONE version to use (for example, `6.1.0-rc.0`)'
 printf '%s\n' '- `$CAS_NAMESPACE` - CAS namespace (for example, `default`)'
 printf '%s\n' '- `$CAS_NAME` - CAS name (for example, `cas`)'
-printf '%s\n' '- `$CVM_MODE` - Set to `--cvm` for CVM mode, otherwise leave empty for SGX'
-printf '%s\n' '- `$SCONE_ENCLAVE` - In CVM mode, set to `--scone-enclave` for confidential nodes, or leave empty for Kata Pods'
+printf '%s\n' '- `$CAS_ENDPOINT` - Address the manifest targets; keep it in sync with `$CAS_NAME`.`$CAS_NAMESPACE` (default: `cas.default`), or set to an external CAS address to run against one'
+printf '%s\n' '- `$TEE_TYPE` - Set to `cvm` for CVM mode or `sgx` for SGX'
+printf '%s\n' '- `$SCONE_ENCLAVE` - In CVM mode, set to `true` for confidential nodes, or `false` for Kata Pods'
 printf '%s\n' '- `$NAMESPACE` - Kubernetes namespace where the demo runs (default: `default`)'
 printf '%s\n' ''
 printf '%s\n' 'Set `SIGNER` for policy signing:'
@@ -355,7 +356,7 @@ pe "$(cat <<'EOF'
 EOF
 )"
 pe "$(cat <<'EOF'
-retry-spinner --retries 5 --wait 2 -- kubectl logs job/my-rust-app -n ${NAMESPACE} -c reader-1
+retry-spinner --retries 30 --wait 5 -- kubectl logs job/my-rust-app -n ${NAMESPACE} -c reader-1
 EOF
 )"
 pe "$(cat <<'EOF'
@@ -363,7 +364,7 @@ pe "$(cat <<'EOF'
 EOF
 )"
 pe "$(cat <<'EOF'
-retry-spinner --retries 5 --wait 2 -- kubectl logs job/my-rust-app -n ${NAMESPACE} -c reader-2
+retry-spinner --retries 30 --wait 5 -- kubectl logs job/my-rust-app -n ${NAMESPACE} -c reader-2
 EOF
 )"
 pe "$(cat <<'EOF'
@@ -389,7 +390,7 @@ printf '%s\n' 'Your containers should print content from the mounted ConfigMap f
 printf '%s\n' ''
 printf '%s\n' '## 8. Prepare and Apply the SCONE Manifest'
 printf '%s\n' ''
-printf '%s\n' 'First, attest the CAS so the local SCONE CLI has the correct session encryption key. The kubectl path covers an in-cluster CAS; if it fails (typical when `${CAS_NAME}.${CAS_NAMESPACE}` resolves to an external CAS like `scone-cas.cf`), the second branch attests the public CAS directly.'
+printf '%s\n' 'First, attest the CAS so the local SCONE CLI has the correct session encryption key. The kubectl path covers an in-cluster CAS; if it fails (typical when `${CAS_ENDPOINT}` points at an external CAS like `edge.scone-cas.cf`), the second branch attests the public CAS directly.'
 printf '%s\n' ''
 printf "%b" "$RESET"
 
@@ -399,8 +400,9 @@ EOF
 )"
 pe "$(cat <<'EOF'
 kubectl scone cas attest --namespace ${CAS_NAMESPACE} ${CAS_NAME} -C -G -S \
-    || scone cas attest ${CAS_NAME}.${CAS_NAMESPACE} -C -G -S \
-        --only_for_testing-debug --only_for_testing-ignore-signer --only_for_testing-trust-any
+    || scone cas attest ${CAS_ENDPOINT} -C -G -S \
+        --only_for_testing-debug --only_for_testing-ignore-signer --only_for_testing-trust-any \
+    || echo "CAS attestation skipped: ${CAS_ENDPOINT} runs in simulation mode, so it cannot produce a DCAP quote"
 EOF
 )"
 
@@ -413,7 +415,7 @@ pe "$(cat <<'EOF'
 EOF
 )"
 pe "$(cat <<'EOF'
-scone-td-build from -y manifests/scone.yaml
+scone-td-build apply -f manifests/scone.yaml
 EOF
 )"
 
@@ -449,7 +451,7 @@ pe "$(cat <<'EOF'
 EOF
 )"
 pe "$(cat <<'EOF'
-retry-spinner -- kubectl logs job/my-rust-app -n ${NAMESPACE} -c reader-1 --follow
+retry-spinner --retries 30 --wait 5 -- kubectl logs job/my-rust-app -n ${NAMESPACE} -c reader-1 --follow
 EOF
 )"
 pe "$(cat <<'EOF'
@@ -457,7 +459,7 @@ pe "$(cat <<'EOF'
 EOF
 )"
 pe "$(cat <<'EOF'
-retry-spinner -- kubectl logs job/my-rust-app -n ${NAMESPACE} -c reader-2 --follow
+retry-spinner --retries 30 --wait 5 -- kubectl logs job/my-rust-app -n ${NAMESPACE} -c reader-2 --follow
 EOF
 )"
 

--- a/docs/flask-redis-netshield.sh
+++ b/docs/flask-redis-netshield.sh
@@ -874,7 +874,7 @@ pe "$(cat <<'EOF'
 EOF
 )"
 pe "$(cat <<'EOF'
-scone-td-build from -y scone.yaml
+scone-td-build apply -f scone.yaml
 EOF
 )"
 pe "$(cat <<'EOF'

--- a/docs/flask-redis.sh
+++ b/docs/flask-redis.sh
@@ -939,7 +939,7 @@ pe "$(cat <<'EOF'
 EOF
 )"
 pe "$(cat <<'EOF'
-scone-td-build from -y scone.yaml
+scone-td-build apply -f scone.yaml
 EOF
 )"
 pe "$(cat <<'EOF'

--- a/docs/go-args-env-file.sh
+++ b/docs/go-args-env-file.sh
@@ -178,8 +178,9 @@ printf '%s\n' '- `$IMAGE_PULL_SECRET_NAME` — Pull secret name (default: `scone
 printf '%s\n' '- `$SCONE_RUNTIME_VERSION` — SCONE version to use (for example, `6.1.0-rc.0`)'
 printf '%s\n' '- `$CAS_NAMESPACE` — CAS namespace (for example, `default`)'
 printf '%s\n' '- `$CAS_NAME` — CAS name (for example, `cas`)'
-printf '%s\n' '- `$CVM_MODE` — Set to `--cvm` for CVM mode, otherwise leave empty for SGX'
-printf '%s\n' '- `$SCONE_ENCLAVE` — In CVM mode, set to `--scone-enclave` for confidential nodes, or leave empty for Kata Pods'
+printf '%s\n' '- `$CAS_ENDPOINT` - Address the manifest targets; keep it in sync with `$CAS_NAME`.`$CAS_NAMESPACE` (default: `cas.default`), or set to an external CAS address to run against one'
+printf '%s\n' '- `$TEE_TYPE` — Set to `cvm` for CVM mode or `sgx` for SGX'
+printf '%s\n' '- `$SCONE_ENCLAVE` - In CVM mode, set to `true` for confidential nodes, or `false` for Kata Pods'
 printf '%s\n' '- `$NAMESPACE` — Kubernetes namespace where the demo runs (default: `default`)'
 printf '%s\n' ''
 printf '%s\n' 'Set `SIGNER` for policy signing:'
@@ -414,7 +415,7 @@ printf '%s\n' '---'
 printf '%s\n' ''
 printf '%s\n' '## 8. Prepare and Apply the SCONE Manifest'
 printf '%s\n' ''
-printf '%s\n' 'First, attest the CAS so the local SCONE CLI has the correct session encryption key. The kubectl path covers an in-cluster CAS; if it fails (typical when `${CAS_NAME}.${CAS_NAMESPACE}` resolves to an external CAS like `scone-cas.cf`), the second branch attests the public CAS directly.'
+printf '%s\n' 'First, attest the CAS so the local SCONE CLI has the correct session encryption key. The kubectl path covers an in-cluster CAS; if it fails (typical when `${CAS_ENDPOINT}` points at an external CAS like `edge.scone-cas.cf`), the second branch attests the public CAS directly.'
 printf '%s\n' ''
 printf "%b" "$RESET"
 
@@ -424,8 +425,9 @@ EOF
 )"
 pe "$(cat <<'EOF'
 kubectl scone cas attest --namespace ${CAS_NAMESPACE} ${CAS_NAME} -C -G -S \
-    || scone cas attest ${CAS_NAME}.${CAS_NAMESPACE} -C -G -S \
-        --only_for_testing-debug --only_for_testing-ignore-signer --only_for_testing-trust-any
+    || scone cas attest ${CAS_ENDPOINT} -C -G -S \
+        --only_for_testing-debug --only_for_testing-ignore-signer --only_for_testing-trust-any \
+    || echo "CAS attestation skipped: ${CAS_ENDPOINT} runs in simulation mode, so it cannot produce a DCAP quote"
 EOF
 )"
 
@@ -440,7 +442,7 @@ pe "$(cat <<'EOF'
 EOF
 )"
 pe "$(cat <<'EOF'
-scone-td-build from -y manifests/scone.yaml
+scone-td-build apply -f manifests/scone.yaml
 EOF
 )"
 

--- a/docs/hello-world.sh
+++ b/docs/hello-world.sh
@@ -169,8 +169,9 @@ printf '%s\n' '- `$DESTINATION_IMAGE_NAME` - Name of the confidential image'
 printf '%s\n' '- `$SCONE_VERSION` - SCONE version to use (for example, `6.1.0-rc.0`)'
 printf '%s\n' '- `$CAS_NAMESPACE` - CAS Kubernetes namespace (for example, `default`)'
 printf '%s\n' '- `$CAS_NAME` - CAS Kubernetes name (for example, `cas`)'
-printf '%s\n' '- `$CVM_MODE` - Set to `--cvm` for CVM mode, otherwise leave empty for SGX'
-printf '%s\n' '- `$SCONE_ENCLAVE` - In CVM mode, set to `--scone-enclave` for confidential nodes, or leave empty for Kata Pods'
+printf '%s\n' '- `$CAS_ENDPOINT` - Address the manifest targets; keep it in sync with `$CAS_NAME`.`$CAS_NAMESPACE` (default: `cas.default`), or set to an external CAS address to run against one'
+printf '%s\n' '- `$TEE_TYPE` - Set to `cvm` for CVM mode or `sgx` for SGX'
+printf '%s\n' '- `$SCONE_ENCLAVE` - In CVM mode, set to `true` for confidential nodes, or `false` for Kata Pods'
 printf '%s\n' '- `$NAMESPACE` - Kubernetes namespace where the demo runs (default: `default`)'
 printf '%s\n' ''
 printf '%s\n' 'Defaults are stored in `Values.yaml`. We use [`tplenv`](https://github.com/scontainug/tplenv) to confirm or override values:'
@@ -211,6 +212,14 @@ EOF
 )"
 pe "$(cat <<'EOF'
 tplenv --file manifest.job.template.yaml --create-values-file --output manifest.job.yaml
+EOF
+)"
+pe "$(cat <<'EOF'
+# Render the SCONE manifest that drives register plus apply.
+EOF
+)"
+pe "$(cat <<'EOF'
+tplenv --file scone.template.yaml --create-values-file --output scone.yaml --indent
 EOF
 )"
 
@@ -475,7 +484,7 @@ printf "%b" "$LILAC"
 printf '%s\n' ''
 printf '%s\n' '## 6. Attest SCONE CAS'
 printf '%s\n' ''
-printf '%s\n' 'Attest CAS before sending encrypted policies. The kubectl path covers in-cluster CAS; if it fails (typical when `${CAS_NAME}.${CAS_NAMESPACE}` resolves to an external CAS like `scone-cas.cf`), the second branch attests the public CAS directly.'
+printf '%s\n' 'Attest CAS before sending encrypted policies. The kubectl path covers in-cluster CAS; if it fails (typical when `${CAS_ENDPOINT}` points at an external CAS like `edge.scone-cas.cf`), the second branch attests the public CAS directly.'
 printf '%s\n' ''
 printf "%b" "$RESET"
 
@@ -485,8 +494,9 @@ EOF
 )"
 pe "$(cat <<'EOF'
 kubectl scone cas attest --namespace ${CAS_NAMESPACE} ${CAS_NAME} -C -G -S \
-    || scone cas attest ${CAS_NAME}.${CAS_NAMESPACE} -C -G -S \
-        --only_for_testing-debug --only_for_testing-ignore-signer --only_for_testing-trust-any
+    || scone cas attest ${CAS_ENDPOINT} -C -G -S \
+        --only_for_testing-debug --only_for_testing-ignore-signer --only_for_testing-trust-any \
+    || echo "CAS attestation skipped: ${CAS_ENDPOINT} runs in simulation mode, so it cannot produce a DCAP quote"
 EOF
 )"
 
@@ -496,39 +506,30 @@ printf '%s\n' 'If attestation fails, inspect the command output for detected vul
 printf '%s\n' ''
 printf '%s\n' '## 7. Register the Confidential Image'
 printf '%s\n' ''
-printf '%s\n' 'Register the image for confidential execution:'
+printf '%s\n' '`scone.yaml` holds both documents: the `Register` that produces the protected image and'
+printf '%s\n' 'the `Apply` that turns `manifest.job.yaml` into a sanitized confidential manifest. A'
+printf '%s\n' 'single command runs both:'
 printf '%s\n' ''
 printf "%b" "$RESET"
 
 pe "$(cat <<'EOF'
-# Register the image for confidential execution.
+# Register the image and transform the manifest in one step.
 EOF
 )"
 pe "$(cat <<'EOF'
-scone-td-build register --protected-image $IMAGE_NAME --unprotected-image rust:latest --manifest-env SCONE_PRODUCTION=0 -s ./storage.json --destination-image ${DESTINATION_IMAGE_NAME} --push --version ${SCONE_RUNTIME_VERSION} ${CVM_MODE}
+scone-td-build apply -f scone.yaml
 EOF
 )"
 
 printf "%b" "$LILAC"
 printf '%s\n' ''
-printf '%s\n' 'This creates a protected image (or uses `--destination-image` if provided) and decouples your deployment from upstream image changes.'
+printf '%s\n' 'This creates a protected image (or uses `output-image` if provided) and decouples your'
+printf '%s\n' 'deployment from upstream image changes.'
 printf '%s\n' ''
 printf '%s\n' '## 8. Transform the Kubernetes Manifest'
 printf '%s\n' ''
-printf '%s\n' 'Convert the native manifest into a sanitized confidential manifest:'
-printf '%s\n' ''
-printf "%b" "$RESET"
-
-pe "$(cat <<'EOF'
-# Convert the native manifest into a confidential manifest.
-EOF
-)"
-pe "$(cat <<'EOF'
-scone-td-build apply -f manifest.job.yaml -c ${CAS_NAME}.${CAS_NAMESPACE} -p -s ./storage.json --manifest-env SCONE_SYSLIBS=1 --manifest-env SCONE_PRODUCTION=0 --manifest-env SCONE_HEAP=1G --spol --manifest-env SCONE_VERSION=1 --output-manifest-file manifest.job.sanitized.yaml --version ${SCONE_RUNTIME_VERSION} ${CVM_MODE} ${SCONE_ENCLAVE}
-EOF
-)"
-
-printf "%b" "$LILAC"
+printf '%s\n' 'The previous step already wrote `manifest.job.sanitized.yaml`, the confidential manifest'
+printf '%s\n' 'declared as `output-manifest` in `scone.yaml`.'
 printf '%s\n' ''
 printf '%s\n' '## 9. Deploy the Confidential Manifest'
 printf '%s\n' ''

--- a/docs/java-args-env-file.sh
+++ b/docs/java-args-env-file.sh
@@ -162,8 +162,9 @@ printf '%s\n' '- `$IMAGE_PULL_SECRET_NAME` — Pull secret name (default: `scone
 printf '%s\n' '- `$SCONE_VERSION` — SCONE version to use (for example, `6.1.0-rc.0`)'
 printf '%s\n' '- `$CAS_NAMESPACE` — CAS namespace (for example, `default`)'
 printf '%s\n' '- `$CAS_NAME` — CAS name (for example, `cas`)'
-printf '%s\n' '- `$CVM_MODE` — Set to `--cvm` for CVM mode, otherwise leave empty for SGX'
-printf '%s\n' '- `$SCONE_ENCLAVE` — In CVM mode, set to `--scone-enclave` for confidential nodes, or leave empty for Kata Pods'
+printf '%s\n' '- `$CAS_ENDPOINT` - Address the manifest targets; keep it in sync with `$CAS_NAME`.`$CAS_NAMESPACE` (default: `cas.default`), or set to an external CAS address to run against one'
+printf '%s\n' '- `$TEE_TYPE` — Set to `cvm` for CVM mode or `sgx` for SGX'
+printf '%s\n' '- `$SCONE_ENCLAVE` - In CVM mode, set to `true` for confidential nodes, or `false` for Kata Pods'
 printf '%s\n' '- `$NAMESPACE` — namespace name (for example, `java-demo`)'
 printf '%s\n' ''
 printf '%s\n' 'Assume you start in `scone-td-build-demos` and switch into this demo directory:'
@@ -322,7 +323,7 @@ pe "$(cat <<'EOF'
 EOF
 )"
 pe "$(cat <<'EOF'
-retry-spinner --retries 10 --wait 2 -- kubectl logs deployment/java-args-env-file -n "${NAMESPACE}" --follow
+retry-spinner --retries 30 --wait 5 -- kubectl logs deployment/java-args-env-file -n "${NAMESPACE}" --follow
 EOF
 )"
 
@@ -353,7 +354,7 @@ printf '%s\n' '---'
 printf '%s\n' ''
 printf '%s\n' '## 8. Prepare and Apply the SCONE Manifest'
 printf '%s\n' ''
-printf '%s\n' 'First, attest the CAS so the local SCONE CLI has the correct session encryption key. The kubectl path covers an in-cluster CAS; if it fails (typical when `${CAS_NAME}.${CAS_NAMESPACE}` resolves to an external CAS like `scone-cas.cf`), the second branch attests the public CAS directly.'
+printf '%s\n' 'First, attest the CAS so the local SCONE CLI has the correct session encryption key. The kubectl path covers an in-cluster CAS; if it fails (typical when `${CAS_ENDPOINT}` points at an external CAS like `edge.scone-cas.cf`), the second branch attests the public CAS directly.'
 printf '%s\n' ''
 printf "%b" "$RESET"
 
@@ -363,8 +364,9 @@ EOF
 )"
 pe "$(cat <<'EOF'
 kubectl scone cas attest --namespace ${CAS_NAMESPACE} ${CAS_NAME} -C -G -S \
-    || scone cas attest ${CAS_NAME}.${CAS_NAMESPACE} -C -G -S \
-        --only_for_testing-debug --only_for_testing-ignore-signer --only_for_testing-trust-any
+    || scone cas attest ${CAS_ENDPOINT} -C -G -S \
+        --only_for_testing-debug --only_for_testing-ignore-signer --only_for_testing-trust-any \
+    || echo "CAS attestation skipped: ${CAS_ENDPOINT} runs in simulation mode, so it cannot produce a DCAP quote"
 EOF
 )"
 
@@ -379,7 +381,7 @@ pe "$(cat <<'EOF'
 EOF
 )"
 pe "$(cat <<'EOF'
-scone-td-build from -y manifests/scone.yaml
+scone-td-build apply -f manifests/scone.yaml
 EOF
 )"
 
@@ -419,7 +421,7 @@ pe "$(cat <<'EOF'
 EOF
 )"
 pe "$(cat <<'EOF'
-retry-spinner -- kubectl logs deployment/java-args-env-file -n "${NAMESPACE}" --follow
+retry-spinner --retries 30 --wait 5 -- kubectl logs deployment/java-args-env-file -n "${NAMESPACE}" --follow
 EOF
 )"
 

--- a/docs/network-policy.sh
+++ b/docs/network-policy.sh
@@ -268,7 +268,7 @@ pe "$(cat <<'EOF'
 EOF
 )"
 pe "$(cat <<'EOF'
-scone-td-build from -y ./scone.yaml
+scone-td-build apply -f ./scone.yaml
 EOF
 )"
 

--- a/docs/software-updates.sh
+++ b/docs/software-updates.sh
@@ -179,7 +179,7 @@ EOF
 printf "%b" "$LILAC"
 printf '%s\n' ''
 printf '%s\n' 'Load the full variable set from `environment-variables.md` first, so `NAMESPACE` and'
-printf '%s\n' '`CVM_MODE` are available to derive the CAS session namespace below:'
+printf '%s\n' '`TEE_TYPE` are available to derive the CAS session namespace below:'
 printf '%s\n' ''
 printf "%b" "$RESET"
 
@@ -207,7 +207,7 @@ export SIGNER="$(scone self show-session-signing-key)"
 EOF
 )"
 pe "$(cat <<'EOF'
-# Fixed per Kubernetes NAMESPACE and CVM_MODE on purpose: CAS sessions are append-only
+# Fixed per Kubernetes NAMESPACE and TEE_TYPE on purpose: CAS sessions are append-only
 EOF
 )"
 pe "$(cat <<'EOF'
@@ -247,7 +247,7 @@ mode_suffix="sgx"
 EOF
 )"
 pe "$(cat <<'EOF'
-if [ "${CVM_MODE}" = "true" ]; then
+if [ "${TEE_TYPE}" = "cvm" ]; then
 EOF
 )"
 pe "$(cat <<'EOF'
@@ -513,7 +513,7 @@ pe "$(cat <<'EOF'
 EOF
 )"
 pe "$(cat <<'EOF'
-scone-td-build from -y scone.v1.yaml
+scone-td-build apply -f scone.v1.yaml
 EOF
 )"
 
@@ -642,7 +642,7 @@ pe "$(cat <<'EOF'
 EOF
 )"
 pe "$(cat <<'EOF'
-scone-td-build from -y scone.v2.yaml
+scone-td-build apply -f scone.v2.yaml
 EOF
 )"
 
@@ -851,7 +851,7 @@ printf '%s\n' 'This does not, and cannot, delete the CAS-side session under `${S
 printf '%s\n' 'sessions are append-only and the `scone` CLI has no session-delete operation, by design,'
 printf '%s\n' 'so the audit trail of every update stays intact. Since `${SESSION_NAMESPACE}` is fixed'
 printf '%s\n' 'per `NAMESPACE`/mode (see Step 1), re-running this demo later with the same `NAMESPACE`'
-printf '%s\n' 'and `CVM_MODE` updates that same session in place instead of leaving a new one behind, so'
+printf '%s\n' 'and `TEE_TYPE` updates that same session in place instead of leaving a new one behind, so'
 printf '%s\n' 'there'\''s no unbounded buildup of sessions or generated `API_PASSWORD` values across runs.'
 printf '%s\n' 'Different namespaces or modes (including the SGX and CVM CI sweeps) each get their own'
 printf '%s\n' 'isolated session instead of sharing one.'

--- a/docs/web-server.sh
+++ b/docs/web-server.sh
@@ -198,8 +198,9 @@ printf '%s\n' '- `$IMAGE_PULL_SECRET_NAME` - Pull secret name (default: `sconeap
 printf '%s\n' '- `$SCONE_RUNTIME_VERSION` - SCONE version to use (for example, `6.1.0-rc.0`)'
 printf '%s\n' '- `$CAS_NAMESPACE` - CAS namespace (for example, `default`)'
 printf '%s\n' '- `$CAS_NAME` - CAS name (for example, `cas`)'
-printf '%s\n' '- `$CVM_MODE` - Set to `--cvm` for CVM mode, otherwise leave empty for SGX'
-printf '%s\n' '- `$SCONE_ENCLAVE` - In CVM mode, set to `--scone-enclave` for confidential nodes, or leave empty for Kata Pods'
+printf '%s\n' '- `$CAS_ENDPOINT` - Address the manifest targets; keep it in sync with `$CAS_NAME`.`$CAS_NAMESPACE` (default: `cas.default`), or set to an external CAS address to run against one'
+printf '%s\n' '- `$TEE_TYPE` - Set to `cvm` for CVM mode or `sgx` for SGX'
+printf '%s\n' '- `$SCONE_ENCLAVE` - In CVM mode, set to `true` for confidential nodes, or `false` for Kata Pods'
 printf '%s\n' '- `$NAMESPACE` - Kubernetes namespace where the demo runs (default: `default`)'
 printf '%s\n' ''
 printf "%b" "$RESET"
@@ -230,7 +231,7 @@ EOF
 
 printf "%b" "$LILAC"
 printf '%s\n' ''
-printf '%s\n' 'Attest CAS before sending encrypted policies. The kubectl path covers in-cluster CAS; if it fails (typical when `${CAS_NAME}.${CAS_NAMESPACE}` resolves to an external CAS like `scone-cas.cf`), the second branch attests the public CAS directly.'
+printf '%s\n' 'Attest CAS before sending encrypted policies. The kubectl path covers in-cluster CAS; if it fails (typical when `${CAS_ENDPOINT}` points at an external CAS like `edge.scone-cas.cf`), the second branch attests the public CAS directly.'
 printf '%s\n' ''
 printf "%b" "$RESET"
 
@@ -240,8 +241,9 @@ EOF
 )"
 pe "$(cat <<'EOF'
 kubectl scone cas attest --namespace ${CAS_NAMESPACE} ${CAS_NAME} -C -G -S \
-    || scone cas attest ${CAS_NAME}.${CAS_NAMESPACE} -C -G -S \
-        --only_for_testing-debug --only_for_testing-ignore-signer --only_for_testing-trust-any
+    || scone cas attest ${CAS_ENDPOINT} -C -G -S \
+        --only_for_testing-debug --only_for_testing-ignore-signer --only_for_testing-trust-any \
+    || echo "CAS attestation skipped: ${CAS_ENDPOINT} runs in simulation mode, so it cannot produce a DCAP quote"
 EOF
 )"
 
@@ -259,6 +261,14 @@ EOF
 )"
 pe "$(cat <<'EOF'
 tplenv --file manifest.template.yaml --create-values-file --output manifest.yaml
+EOF
+)"
+pe "$(cat <<'EOF'
+# Render the SCONE manifest that drives register plus apply.
+EOF
+)"
+pe "$(cat <<'EOF'
+tplenv --file scone.template.yaml --create-values-file --output scone.yaml --indent
 EOF
 )"
 
@@ -377,28 +387,8 @@ EOF
 
 printf "%b" "$LILAC"
 printf '%s\n' ''
-printf '%s\n' 'Register the image with `scone-td-build`:'
-printf '%s\n' ''
-printf "%b" "$RESET"
-
-pe "$(cat <<'EOF'
-# Register the image for confidential execution.
-EOF
-)"
-pe "$(cat <<'EOF'
-scone-td-build register \
-  --protected-image ${IMAGE_NAME} \
-  --unprotected-image ${IMAGE_NAME} \
-  --destination-image ${DESTINATION_IMAGE_NAME} \
-  --push \
-  -s ./storage.json \
-  --enforce /app/web-server \
-  --version ${SCONE_RUNTIME_VERSION} \
-  ${CVM_MODE}
-EOF
-)"
-
-printf "%b" "$LILAC"
+printf '%s\n' '`scone.yaml` declares the `Register` for this image and the `Apply` that transforms the'
+printf '%s\n' 'manifest, so both run from a single command in the conversion step below.'
 printf '%s\n' ''
 printf '%s\n' '## 6. Test the Native Manifest (Optional)'
 printf '%s\n' ''
@@ -490,7 +480,7 @@ pe "$(cat <<'EOF'
 EOF
 )"
 pe "$(cat <<'EOF'
-retry-spinner -- curl http://localhost:8000/env/MY_POD_IP
+retry-spinner --retries 40 --wait 10 -- curl http://localhost:8000/env/MY_POD_IP
 EOF
 )"
 pe "$(cat <<'EOF'
@@ -547,23 +537,11 @@ printf '%s\n' ''
 printf "%b" "$RESET"
 
 pe "$(cat <<'EOF'
-# Convert the native manifest into a confidential manifest.
+# Register the image and transform the manifest in one step.
 EOF
 )"
 pe "$(cat <<'EOF'
-scone-td-build apply \
-  -f manifest.yaml \
-  -c ${CAS_NAME}.${CAS_NAMESPACE} \
-  -s ./storage.json \
-  --spol \
-  --manifest-env SCONE_SYSLIBS=1 \
-  --manifest-env SCONE_PRODUCTION=0 \
-  --manifest-env SCONE_VERSION=1 \
-  --manifest-env SCONE_HEAP=2G \
-  --session-env SCONE_VERSION=1 \
-  --output-manifest-file manifest.sanitized.yaml \
-  --version ${SCONE_RUNTIME_VERSION} -p \
-  ${CVM_MODE} ${SCONE_ENCLAVE}
+scone-td-build apply -f scone.yaml
 EOF
 )"
 

--- a/flask-redis-netshield/README.md
+++ b/flask-redis-netshield/README.md
@@ -322,7 +322,7 @@ tplenv --file scone.template.yaml --create-values-file --output scone.yaml --ind
 # Remove `flask-redis-demo.json` if it exists.
 rm flask-redis-demo.json || true
 # Generate the confidential image and sanitized manifest from the SCONE configuration.
-scone-td-build from -y scone.yaml
+scone-td-build apply -f scone.yaml
 # Use the registry-backed Redis SCONE image that the Register step pushed.
 if grep -q 'image: redis:7-bookworm-scone' manifest.prod.sanitized.yaml; then
   sed -i.bak "s|image: redis:7-bookworm-scone|image: ${IMAGE_NAME}-redis-scone|g" manifest.prod.sanitized.yaml

--- a/flask-redis-netshield/Values.yaml
+++ b/flask-redis-netshield/Values.yaml
@@ -2,13 +2,10 @@ environment:
   IMAGE_PULL_SECRET_NAME: sconeapps
   CAS_NAMESPACE: default
   CAS_NAME: cas
+  CAS_ENDPOINT: cas.default
   SCONE_RUNTIME_VERSION: 6.1.0-rc.0
-  CVM_MODE: 'false'
+  TEE_TYPE: sgx
   SCONE_ENCLAVE: 'false'
   REGISTRY: registry.scontain.com
-  IMAGE_NAME: registry.scontain.com/k8s-scone-images/flask-redis-netshield:latest
+  IMAGE_NAME: registry.scontain.com/k8s-scone-images/flask-redis:latest-netshield
   NAMESPACE: scone-tools
-  SIGNER: |-
-    -----BEGIN PUBLIC KEY-----
-    MCowBQYDK2VwAyEAvSRST+dhEaX42c6VkY1Sv+KVelnSup96M6TMHOlqcrg=
-    -----END PUBLIC KEY-----

--- a/flask-redis-netshield/environment-variables.md
+++ b/flask-redis-netshield/environment-variables.md
@@ -6,10 +6,11 @@ This file defines the environment variables used to configure the `flask-redis-n
 4. The SCONE version is stored in `${SCONE_RUNTIME_VERSION}`.
    The current value is `6.1.0-rc.0`.
 5. The CAS runs in Kubernetes namespace `${CAS_NAMESPACE}`.
-   The templates resolve `${CAS_NAME}.${CAS_NAMESPACE}` to the CAS endpoint, so for SCONE's public CAS at `scone-cas.cf` set `CAS_NAMESPACE=cf`.
+   `${CAS_NAME}` and `${CAS_NAMESPACE}` address the in-cluster CAS for `kubectl` calls.
 6. The CAS name is stored in `${CAS_NAME}`.
-   For SCONE's public CAS, set `CAS_NAME=scone-cas`.
-7. If you want to use CVM mode, set `${CVM_MODE}` to `true`. For SGX, set to `false`.
+   The manifests use `${CAS_ENDPOINT}` instead, which defaults to `cas.default`. Point it at
+   a public CAS to run against one, for example `CAS_ENDPOINT=edge.scone-cas.cf`.
+7. Set `${TEE_TYPE}` to `cvm` for CVM mode or `sgx` for SGX.
 8. In CVM mode, you can run on confidential Kubernetes nodes or Kata Pods.
    We recommend using confidential nodes and setting `${SCONE_ENCLAVE}` to `true`.
 9. Set the local signer key in `${SIGNER}`.

--- a/flask-redis-netshield/scone.template.yaml
+++ b/flask-redis-netshield/scone.template.yaml
@@ -3,14 +3,14 @@ kind: Register
 metadata:
   name: flask-redis-demo
 spec:
-  protected_image: redis:7-bookworm
-  unprotected_image: redis:7-bookworm
-  destination_image: ${IMAGE_NAME}-redis-scone
-  enforce: ["/usr/local/bin/redis-server"]
-  push_scone_image: true
-  cvm: ${CVM_MODE}
-  version: ${SCONE_RUNTIME_VERSION}
-  manifest_env:
+  source-image: redis:7-bookworm
+  reference-image: redis:7-bookworm
+  output-image: ${IMAGE_NAME}-redis-scone
+  protected-binaries: ["/usr/local/bin/redis-server"]
+  push-image: true
+  tee-type: ${TEE_TYPE}
+  scone-version: ${SCONE_RUNTIME_VERSION}
+  container-env:
     - {name: SCONE_VERSION, value: "1"}
     - {name: SCONE_SYSLIBS, value: "1"}
     - {name: SCONE_PRODUCTION, value: "0"}
@@ -21,13 +21,13 @@ kind: Register
 metadata:
   name: flask-redis-demo
 spec:
-  protected_image: ${IMAGE_NAME}
-  unprotected_image: ${IMAGE_NAME}
-  enforce: ["/usr/local/bin/python"]
-  push_scone_image: true
-  cvm: ${CVM_MODE}
-  version: ${SCONE_RUNTIME_VERSION}
-  manifest_env:
+  source-image: ${IMAGE_NAME}
+  reference-image: ${IMAGE_NAME}
+  protected-binaries: ["/usr/local/bin/python"]
+  push-image: true
+  tee-type: ${TEE_TYPE}
+  scone-version: ${SCONE_RUNTIME_VERSION}
+  container-env:
     - {name: SCONE_VERSION, value: "1"}
     - {name: SCONE_SYSLIBS, value: "1"}
     - {name: SCONE_PRODUCTION, value: "0"}
@@ -43,23 +43,23 @@ spec:
     - "k8s/manifest.yaml"
     - "k8s/secret-flask-tls.yaml"
     - "k8s/secret-redis-tls.yaml"
-  output_manifest_file: "manifest.prod.sanitized.yaml"
-  output_session_file: "manifest.prod.session.yaml"
-  cas_address:
-    address: ${CAS_NAME}.${CAS_NAMESPACE}
-  session_env:
+  output-manifest: "manifest.prod.sanitized.yaml"
+  output-session: "manifest.prod.session.yaml"
+  cas-endpoint:
+    address: ${CAS_ENDPOINT}
+  cas-policy-env:
     - {name: SCONE_VERSION, value: "1"}
-  manifest_env:
+  container-env:
     - {name: SCONE_VERSION, value: "1"}
     - {name: SCONE_SYSLIBS, value: "1"}
     - {name: SCONE_PRODUCTION, value: "0"}
     - {name: SCONE_HEAP, value: "2G"}
     - {name: SCONE_ALLOW_DLOPEN, value: "2" }
   permissive: true
-  spol: true
-  cvm: ${CVM_MODE}
-  scone_enclave: ${SCONE_ENCLAVE}
-  version: ${SCONE_RUNTIME_VERSION}
+  encrypted-cas-policy: false
+  tee-type: ${TEE_TYPE}
+  scone-enclave: ${SCONE_ENCLAVE}
+  scone-version: ${SCONE_RUNTIME_VERSION}
   access_policy:
     read:
       - ANY

--- a/flask-redis/README.md
+++ b/flask-redis/README.md
@@ -339,7 +339,7 @@ tplenv --file scone.template.yaml --create-values-file --output scone.yaml --ind
 # Remove `flask-redis-demo.json` if it exists.
 rm flask-redis-demo.json || true
 # Generate the confidential image and sanitized manifest from the SCONE configuration.
-scone-td-build from -y scone.yaml
+scone-td-build apply -f scone.yaml
 # Use the registry-backed Redis SCONE image that the Register step pushed.
 if grep -q 'image: redis:7-bookworm-scone' manifest.prod.sanitized.yaml; then
   sed -i.bak "s|image: redis:7-bookworm-scone|image: ${IMAGE_NAME}-redis-scone|g" manifest.prod.sanitized.yaml

--- a/flask-redis/Values.yaml
+++ b/flask-redis/Values.yaml
@@ -2,13 +2,10 @@ environment:
   IMAGE_PULL_SECRET_NAME: sconeapps
   CAS_NAMESPACE: default
   CAS_NAME: cas
+  CAS_ENDPOINT: cas.default
   SCONE_RUNTIME_VERSION: 6.1.0-rc.0
-  CVM_MODE: 'false'
+  TEE_TYPE: sgx
   SCONE_ENCLAVE: 'false'
   REGISTRY: registry.scontain.com
   IMAGE_NAME: registry.scontain.com/k8s-scone-images/flask-redis:latest
   NAMESPACE: scone-tools
-  SIGNER: |-
-    -----BEGIN PUBLIC KEY-----
-    MCowBQYDK2VwAyEAvSRST+dhEaX42c6VkY1Sv+KVelnSup96M6TMHOlqcrg=
-    -----END PUBLIC KEY-----

--- a/flask-redis/environment-variables.md
+++ b/flask-redis/environment-variables.md
@@ -6,10 +6,11 @@ This file defines the environment variables used to configure the `flask-redis` 
 4. The SCONE version is stored in `${SCONE_RUNTIME_VERSION}`.
    The current value is `6.1.0-rc.0`.
 5. The CAS runs in Kubernetes namespace `${CAS_NAMESPACE}`.
-   The templates resolve `${CAS_NAME}.${CAS_NAMESPACE}` to the CAS endpoint, so for SCONE's public CAS at `scone-cas.cf` set `CAS_NAMESPACE=cf`.
+   `${CAS_NAME}` and `${CAS_NAMESPACE}` address the in-cluster CAS for `kubectl` calls.
 6. The CAS name is stored in `${CAS_NAME}`.
-   For SCONE's public CAS, set `CAS_NAME=scone-cas`.
-7. If you want to use CVM mode, set `${CVM_MODE}` to `true`. For SGX, set to `false`.
+   The manifests use `${CAS_ENDPOINT}` instead, which defaults to `cas.default`. Point it at
+   a public CAS to run against one, for example `CAS_ENDPOINT=edge.scone-cas.cf`.
+7. Set `${TEE_TYPE}` to `cvm` for CVM mode or `sgx` for SGX.
 8. In CVM mode, you can run on confidential Kubernetes nodes or Kata Pods.
    We recommend using confidential nodes and setting `${SCONE_ENCLAVE}` to `true`.
 9. Set the local signer key in `${SIGNER}`.

--- a/flask-redis/scone.template.yaml
+++ b/flask-redis/scone.template.yaml
@@ -3,14 +3,14 @@ kind: Register
 metadata:
   name: flask-redis-demo
 spec:
-  protected_image: redis:7-bookworm
-  unprotected_image: redis:7-bookworm
-  destination_image: ${IMAGE_NAME}-redis-scone
-  enforce: ["/usr/local/bin/redis-server"]
-  push_scone_image: true
-  cvm: ${CVM_MODE}
-  version: ${SCONE_RUNTIME_VERSION}
-  manifest_env:
+  source-image: redis:7-bookworm
+  reference-image: redis:7-bookworm
+  output-image: ${IMAGE_NAME}-redis-scone
+  protected-binaries: ["/usr/local/bin/redis-server"]
+  push-image: true
+  tee-type: ${TEE_TYPE}
+  scone-version: ${SCONE_RUNTIME_VERSION}
+  container-env:
     - {name: SCONE_VERSION, value: "1"}
     - {name: SCONE_SYSLIBS, value: "1"}
     - {name: SCONE_PRODUCTION, value: "0"}
@@ -21,13 +21,13 @@ kind: Register
 metadata:
   name: flask-redis-demo
 spec:
-  protected_image: ${IMAGE_NAME}
-  unprotected_image: ${IMAGE_NAME}
-  enforce: ["/usr/local/bin/python"]
-  push_scone_image: true
-  cvm: ${CVM_MODE}
-  version: ${SCONE_RUNTIME_VERSION}
-  manifest_env:
+  source-image: ${IMAGE_NAME}
+  reference-image: ${IMAGE_NAME}
+  protected-binaries: ["/usr/local/bin/python"]
+  push-image: true
+  tee-type: ${TEE_TYPE}
+  scone-version: ${SCONE_RUNTIME_VERSION}
+  container-env:
     - {name: SCONE_VERSION, value: "1"}
     - {name: SCONE_SYSLIBS, value: "1"}
     - {name: SCONE_PRODUCTION, value: "0"}
@@ -43,23 +43,23 @@ spec:
     - "k8s/manifest.yaml"
     - "k8s/secret-flask-tls.yaml"
     - "k8s/secret-redis-tls.yaml"
-  output_manifest_file: "manifest.prod.sanitized.yaml"
-  output_session_file: "manifest.prod.session.yaml"
-  cas_address:
-    address: ${CAS_NAME}.${CAS_NAMESPACE}
-  session_env:
+  output-manifest: "manifest.prod.sanitized.yaml"
+  output-session: "manifest.prod.session.yaml"
+  cas-endpoint:
+    address: ${CAS_ENDPOINT}
+  cas-policy-env:
     - {name: SCONE_VERSION, value: "1"}
-  manifest_env:
+  container-env:
     - {name: SCONE_VERSION, value: "1"}
     - {name: SCONE_SYSLIBS, value: "1"}
     - {name: SCONE_PRODUCTION, value: "0"}
     - {name: SCONE_HEAP, value: "2G"}
     - {name: SCONE_ALLOW_DLOPEN, value: "2" }
   permissive: true
-  spol: true
-  cvm: ${CVM_MODE}
-  scone_enclave: ${SCONE_ENCLAVE}
-  version: ${SCONE_RUNTIME_VERSION}
+  encrypted-cas-policy: false
+  tee-type: ${TEE_TYPE}
+  scone-enclave: ${SCONE_ENCLAVE}
+  scone-version: ${SCONE_RUNTIME_VERSION}
   access_policy:
     read:
       - ANY

--- a/go-args-env-file/README.md
+++ b/go-args-env-file/README.md
@@ -58,8 +58,9 @@ Default values are stored in `Values.yaml`. `tplenv` asks whether to keep the de
 - `$SCONE_RUNTIME_VERSION` — SCONE version to use (for example, `6.1.0-rc.0`)
 - `$CAS_NAMESPACE` — CAS namespace (for example, `default`)
 - `$CAS_NAME` — CAS name (for example, `cas`)
-- `$CVM_MODE` — Set to `--cvm` for CVM mode, otherwise leave empty for SGX
-- `$SCONE_ENCLAVE` — In CVM mode, set to `--scone-enclave` for confidential nodes, or leave empty for Kata Pods
+- `$CAS_ENDPOINT` - Address the manifest targets; keep it in sync with `$CAS_NAME`.`$CAS_NAMESPACE` (default: `cas.default`), or set to an external CAS address to run against one
+- `$TEE_TYPE` — Set to `cvm` for CVM mode or `sgx` for SGX
+- `$SCONE_ENCLAVE` - In CVM mode, set to `true` for confidential nodes, or `false` for Kata Pods
 - `$NAMESPACE` — Kubernetes namespace where the demo runs (default: `default`)
 
 Set `SIGNER` for policy signing:
@@ -190,20 +191,21 @@ The manifest mounts:
 
 ## 8. Prepare and Apply the SCONE Manifest
 
-First, attest the CAS so the local SCONE CLI has the correct session encryption key. The kubectl path covers an in-cluster CAS; if it fails (typical when `${CAS_NAME}.${CAS_NAMESPACE}` resolves to an external CAS like `scone-cas.cf`), the second branch attests the public CAS directly.
+First, attest the CAS so the local SCONE CLI has the correct session encryption key. The kubectl path covers an in-cluster CAS; if it fails (typical when `${CAS_ENDPOINT}` points at an external CAS like `edge.scone-cas.cf`), the second branch attests the public CAS directly.
 
 ```bash
 # Attest the CAS instance before sending encrypted policies.
 kubectl scone cas attest --namespace ${CAS_NAMESPACE} ${CAS_NAME} -C -G -S \
-    || scone cas attest ${CAS_NAME}.${CAS_NAMESPACE} -C -G -S \
-        --only_for_testing-debug --only_for_testing-ignore-signer --only_for_testing-trust-any
+    || scone cas attest ${CAS_ENDPOINT} -C -G -S \
+        --only_for_testing-debug --only_for_testing-ignore-signer --only_for_testing-trust-any \
+    || echo "CAS attestation skipped: ${CAS_ENDPOINT} runs in simulation mode, so it cannot produce a DCAP quote"
 ```
 
 Then build the confidential image and generate the SCONE session from `manifests/scone.yaml`:
 
 ```bash
 # Generate the confidential image and sanitized manifest from the SCONE configuration.
-scone-td-build from -y manifests/scone.yaml
+scone-td-build apply -f manifests/scone.yaml
 ```
 
 This command:

--- a/go-args-env-file/Values.yaml
+++ b/go-args-env-file/Values.yaml
@@ -5,11 +5,8 @@ environment:
   IMAGE_PULL_SECRET_NAME: sconeapps
   CAS_NAMESPACE: default
   CAS_NAME: cas
-  CVM_MODE: 'false'
+  CAS_ENDPOINT: cas.default
+  TEE_TYPE: sgx
   SCONE_ENCLAVE: 'false'
   SCONE_RUNTIME_VERSION: 6.1.0-rc.0
   NAMESPACE: default
-  SIGNER: |-
-    -----BEGIN PUBLIC KEY-----
-    MCowBQYDK2VwAyEAvSRST+dhEaX42c6VkY1Sv+KVelnSup96M6TMHOlqcrg=
-    -----END PUBLIC KEY-----

--- a/go-args-env-file/environment-variables.md
+++ b/go-args-env-file/environment-variables.md
@@ -7,10 +7,11 @@ This file defines the environment variables used to configure the `go-args-env-f
 4. The SCONE version is stored in `${SCONE_RUNTIME_VERSION}`.
    The recommended value is `6.1.0-rc.0`.
 5. The CAS runs in Kubernetes namespace `${CAS_NAMESPACE}`.
-   The templates resolve `${CAS_NAME}.${CAS_NAMESPACE}` to the CAS endpoint, so for SCONE's public CAS at `scone-cas.cf` set `CAS_NAMESPACE=cf`.
+   `${CAS_NAME}` and `${CAS_NAMESPACE}` address the in-cluster CAS for `kubectl` calls.
 6. The CAS name is stored in `${CAS_NAME}`.
-   For SCONE's public CAS, set `CAS_NAME=scone-cas`.
-7. If you want to use CVM mode, set `${CVM_MODE}` to `true`. For SGX, set to `false`.
+   The manifests use `${CAS_ENDPOINT}` instead, which defaults to `cas.default`. Point it at
+   a public CAS to run against one, for example `CAS_ENDPOINT=edge.scone-cas.cf`.
+7. Set `${TEE_TYPE}` to `cvm` for CVM mode or `sgx` for SGX.
 8. In CVM mode, you can run on confidential Kubernetes nodes or Kata Pods.
    We recommend using confidential nodes and setting `${SCONE_ENCLAVE}` to `true`.
 9. Set the local signer key in `${SIGNER}`.

--- a/go-args-env-file/manifests/scone.template.yaml
+++ b/go-args-env-file/manifests/scone.template.yaml
@@ -3,14 +3,14 @@ kind: Register
 metadata:
   name: go-args-env-file-example
 spec:
-  protected_image: ${DEMO_IMAGE}
-  unprotected_image: ${DEMO_IMAGE}
-  destination_image: ${DESTINATION_IMAGE_NAME}
-  enforce: ["/usr/local/bin/go-args-env-file"]
-  push_scone_image: true
-  version: ${SCONE_RUNTIME_VERSION}
-  cvm: ${CVM_MODE}
-  manifest_env:
+  source-image: ${DEMO_IMAGE}
+  reference-image: ${DEMO_IMAGE}
+  output-image: ${DESTINATION_IMAGE_NAME}
+  protected-binaries: ["/usr/local/bin/go-args-env-file"]
+  push-image: true
+  scone-version: ${SCONE_RUNTIME_VERSION}
+  tee-type: ${TEE_TYPE}
+  container-env:
     - {name: SCONE_VERSION, value: "1"}
     - {name: SCONE_SYSLIBS, value: "1"}
     - {name: SCONE_PRODUCTION, value: "0"}
@@ -21,21 +21,21 @@ kind: Apply
 metadata:
   name: go-args-env-file-example
 spec:
-  version: ${SCONE_RUNTIME_VERSION}
+  scone-version: ${SCONE_RUNTIME_VERSION}
   file:
     - "manifests/manifest.yaml"
-  output_manifest_file: "manifests/manifest.prod.sanitized.yaml"
-  output_session_file: "manifests/manifest.prod.session.yaml"
-  cas_address:
-    address: ${CAS_NAME}.${CAS_NAMESPACE}
-  session_env:
+  output-manifest: "manifests/manifest.prod.sanitized.yaml"
+  output-session: "manifests/manifest.prod.session.yaml"
+  cas-endpoint:
+    address: ${CAS_ENDPOINT}
+  cas-policy-env:
     - {name: SCONE_VERSION, value: "1"}
-  manifest_env:
+  container-env:
     - {name: SCONE_VERSION, value: "1"}
     - {name: SCONE_SYSLIBS, value: "1"}
     - {name: SCONE_PRODUCTION, value: "0"}
     - {name: SCONE_HEAP, value: "2G"}
   permissive: true
-  spol: true
-  cvm: ${CVM_MODE}
-  scone_enclave: ${SCONE_ENCLAVE}
+  encrypted-cas-policy: false
+  tee-type: ${TEE_TYPE}
+  scone-enclave: ${SCONE_ENCLAVE}

--- a/hello-world/README.md
+++ b/hello-world/README.md
@@ -41,8 +41,9 @@ For the confidential deployment:
 - `$SCONE_VERSION` - SCONE version to use (for example, `6.1.0-rc.0`)
 - `$CAS_NAMESPACE` - CAS Kubernetes namespace (for example, `default`)
 - `$CAS_NAME` - CAS Kubernetes name (for example, `cas`)
-- `$CVM_MODE` - Set to `--cvm` for CVM mode, otherwise leave empty for SGX
-- `$SCONE_ENCLAVE` - In CVM mode, set to `--scone-enclave` for confidential nodes, or leave empty for Kata Pods
+- `$CAS_ENDPOINT` - Address the manifest targets; keep it in sync with `$CAS_NAME`.`$CAS_NAMESPACE` (default: `cas.default`), or set to an external CAS address to run against one
+- `$TEE_TYPE` - Set to `cvm` for CVM mode or `sgx` for SGX
+- `$SCONE_ENCLAVE` - In CVM mode, set to `true` for confidential nodes, or `false` for Kata Pods
 - `$NAMESPACE` - Kubernetes namespace where the demo runs (default: `default`)
 
 Defaults are stored in `Values.yaml`. We use [`tplenv`](https://github.com/scontainug/tplenv) to confirm or override values:
@@ -62,6 +63,8 @@ Generate the job manifest with the selected image and pull-secret values:
 ```bash
 # Render the template with the selected values.
 tplenv --file manifest.job.template.yaml --create-values-file --output manifest.job.yaml
+# Render the SCONE manifest that drives register plus apply.
+tplenv --file scone.template.yaml --create-values-file --output scone.yaml --indent
 ```
 
 ## 3. Build the Native Container Image
@@ -158,36 +161,36 @@ kubectl wait --for=delete pod -l app=hello-world -n ${NAMESPACE} --timeout=300s
 
 ## 6. Attest SCONE CAS
 
-Attest CAS before sending encrypted policies. The kubectl path covers in-cluster CAS; if it fails (typical when `${CAS_NAME}.${CAS_NAMESPACE}` resolves to an external CAS like `scone-cas.cf`), the second branch attests the public CAS directly.
+Attest CAS before sending encrypted policies. The kubectl path covers in-cluster CAS; if it fails (typical when `${CAS_ENDPOINT}` points at an external CAS like `edge.scone-cas.cf`), the second branch attests the public CAS directly.
 
 ```bash
 # Attest the CAS instance before sending encrypted policies.
 kubectl scone cas attest --namespace ${CAS_NAMESPACE} ${CAS_NAME} -C -G -S \
-    || scone cas attest ${CAS_NAME}.${CAS_NAMESPACE} -C -G -S \
-        --only_for_testing-debug --only_for_testing-ignore-signer --only_for_testing-trust-any
+    || scone cas attest ${CAS_ENDPOINT} -C -G -S \
+        --only_for_testing-debug --only_for_testing-ignore-signer --only_for_testing-trust-any \
+    || echo "CAS attestation skipped: ${CAS_ENDPOINT} runs in simulation mode, so it cannot produce a DCAP quote"
 ```
 
 If attestation fails, inspect the command output for detected vulnerabilities and suggested tolerance flags.
 
 ## 7. Register the Confidential Image
 
-Register the image for confidential execution:
+`scone.yaml` holds both documents: the `Register` that produces the protected image and
+the `Apply` that turns `manifest.job.yaml` into a sanitized confidential manifest. A
+single command runs both:
 
 ```bash
-# Register the image for confidential execution.
-scone-td-build register --protected-image $IMAGE_NAME --unprotected-image rust:latest --manifest-env SCONE_PRODUCTION=0 -s ./storage.json --destination-image ${DESTINATION_IMAGE_NAME} --push --version ${SCONE_RUNTIME_VERSION} ${CVM_MODE}
+# Register the image and transform the manifest in one step.
+scone-td-build apply -f scone.yaml
 ```
 
-This creates a protected image (or uses `--destination-image` if provided) and decouples your deployment from upstream image changes.
+This creates a protected image (or uses `output-image` if provided) and decouples your
+deployment from upstream image changes.
 
 ## 8. Transform the Kubernetes Manifest
 
-Convert the native manifest into a sanitized confidential manifest:
-
-```bash
-# Convert the native manifest into a confidential manifest.
-scone-td-build apply -f manifest.job.yaml -c ${CAS_NAME}.${CAS_NAMESPACE} -p -s ./storage.json --manifest-env SCONE_SYSLIBS=1 --manifest-env SCONE_PRODUCTION=0 --manifest-env SCONE_HEAP=1G --spol --manifest-env SCONE_VERSION=1 --output-manifest-file manifest.job.sanitized.yaml --version ${SCONE_RUNTIME_VERSION} ${CVM_MODE} ${SCONE_ENCLAVE}
-```
+The previous step already wrote `manifest.job.sanitized.yaml`, the confidential manifest
+declared as `output-manifest` in `scone.yaml`.
 
 ## 9. Deploy the Confidential Manifest
 

--- a/hello-world/Values.yaml
+++ b/hello-world/Values.yaml
@@ -3,9 +3,10 @@ environment:
   IMAGE_PULL_SECRET_NAME: sconeapps
   CAS_NAMESPACE: default
   CAS_NAME: cas
-  DESTINATION_IMAGE_NAME: registry.scontain.com/workshop/hello-world:protected
-  CVM_MODE: ''
-  SCONE_ENCLAVE: ''
+  CAS_ENDPOINT: cas.default
+  DESTINATION_IMAGE_NAME: registry.scontain.com/k8s-scone-images/hello-world:protected
+  TEE_TYPE: sgx
+  SCONE_ENCLAVE: 'false'
   REGISTRY: registry.scontain.com
   SCONE_RUNTIME_VERSION: 6.1.0-rc.0
   NAMESPACE: default

--- a/hello-world/environment-variables.md
+++ b/hello-world/environment-variables.md
@@ -7,11 +7,12 @@ This file defines the environment variables used to configure this `hello-world`
 4. The SCONE version is stored in `${SCONE_RUNTIME_VERSION}`.
    The current value is `6.1.0-rc.0`.
 5. The CAS runs in Kubernetes namespace `${CAS_NAMESPACE}`.
-   The templates resolve `${CAS_NAME}.${CAS_NAMESPACE}` to the CAS endpoint, so for SCONE's public CAS at `scone-cas.cf` set `CAS_NAMESPACE=cf`.
+   `${CAS_NAME}` and `${CAS_NAMESPACE}` address the in-cluster CAS for `kubectl` calls.
 6. The CAS name is stored in `${CAS_NAME}`.
-   For SCONE's public CAS, set `CAS_NAME=scone-cas`.
-7. If you want to use CVM mode, set `${CVM_MODE}` to `--cvm`. For SGX, leave it empty or single space.
+   The manifests use `${CAS_ENDPOINT}` instead, which defaults to `cas.default`. Point it at
+   a public CAS to run against one, for example `CAS_ENDPOINT=edge.scone-cas.cf`.
+7. Set `${TEE_TYPE}` to `cvm` for CVM mode or `sgx` for SGX.
 8. In CVM mode, you can run on confidential Kubernetes nodes or Kata Pods (set to empty).
-   We recommend using confidential nodes and setting `${SCONE_ENCLAVE}` to `--scone-enclave`.
+   We recommend using confidential nodes and setting `${SCONE_ENCLAVE}` to `true`.
 9. The Kubernetes namespace where the demo manifests are deployed is stored in `${NAMESPACE}`.
    The default value is `default`.

--- a/hello-world/scone.template.yaml
+++ b/hello-world/scone.template.yaml
@@ -1,0 +1,34 @@
+apiVersion: scone.cloud/v1
+kind: Register
+metadata:
+  name: hello-world
+spec:
+  source-image: ${IMAGE_NAME}
+  reference-image: rust:latest
+  output-image: ${DESTINATION_IMAGE_NAME}
+  push-image: true
+  container-env:
+    - {name: SCONE_PRODUCTION, value: "0"}
+  scone-version: ${SCONE_RUNTIME_VERSION}
+  tee-type: ${TEE_TYPE}
+---
+apiVersion: scone.cloud/v1
+kind: Apply
+metadata:
+  name: hello-world
+spec:
+  file:
+    - "manifest.job.yaml"
+  output-manifest: "manifest.job.sanitized.yaml"
+  cas-endpoint:
+    address: ${CAS_ENDPOINT}
+  container-env:
+    - {name: SCONE_SYSLIBS, value: "1"}
+    - {name: SCONE_PRODUCTION, value: "0"}
+    - {name: SCONE_VERSION, value: "1"}
+    - {name: SCONE_HEAP, value: "1G"}
+  permissive: true
+  encrypted-cas-policy: false
+  tee-type: ${TEE_TYPE}
+  scone-enclave: ${SCONE_ENCLAVE}
+  scone-version: ${SCONE_RUNTIME_VERSION}

--- a/image-signing/manifest.job.yaml
+++ b/image-signing/manifest.job.yaml
@@ -1,0 +1,18 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: image-signing
+spec:
+  template:
+    metadata:
+      labels:
+        app: image-signing
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: image-signing
+          image: registry.scontain.com/k8s-scone-images/image-signing:native
+          imagePullPolicy: Always
+      imagePullSecrets:
+        - name: sconeapps
+  backoffLimit: 4

--- a/java-args-env-file/README.md
+++ b/java-args-env-file/README.md
@@ -50,8 +50,9 @@ Default values are stored in `Values.yaml`. `tplenv` asks whether to keep the de
 - `$SCONE_VERSION` — SCONE version to use (for example, `6.1.0-rc.0`)
 - `$CAS_NAMESPACE` — CAS namespace (for example, `default`)
 - `$CAS_NAME` — CAS name (for example, `cas`)
-- `$CVM_MODE` — Set to `--cvm` for CVM mode, otherwise leave empty for SGX
-- `$SCONE_ENCLAVE` — In CVM mode, set to `--scone-enclave` for confidential nodes, or leave empty for Kata Pods
+- `$CAS_ENDPOINT` - Address the manifest targets; keep it in sync with `$CAS_NAME`.`$CAS_NAMESPACE` (default: `cas.default`), or set to an external CAS address to run against one
+- `$TEE_TYPE` — Set to `cvm` for CVM mode or `sgx` for SGX
+- `$SCONE_ENCLAVE` - In CVM mode, set to `true` for confidential nodes, or `false` for Kata Pods
 - `$NAMESPACE` — namespace name (for example, `java-demo`)
 
 Assume you start in `scone-td-build-demos` and switch into this demo directory:
@@ -133,7 +134,7 @@ Apply the manifest and follow the pod logs to confirm the app prints arguments, 
 # Apply the Kubernetes manifest.
 kubectl apply -f manifests/manifest.yaml -n ${NAMESPACE}
 # Follow logs from the Kubernetes workload.
-retry-spinner --retries 10 --wait 2 -- kubectl logs deployment/java-args-env-file -n "${NAMESPACE}" --follow
+retry-spinner --retries 30 --wait 5 -- kubectl logs deployment/java-args-env-file -n "${NAMESPACE}" --follow
 ```
 
 Your container should print the command-line args, all environment variables, the contents of `/config/configs.yaml`, and `/config/secrets`.
@@ -153,20 +154,21 @@ The manifest mounts:
 
 ## 8. Prepare and Apply the SCONE Manifest
 
-First, attest the CAS so the local SCONE CLI has the correct session encryption key. The kubectl path covers an in-cluster CAS; if it fails (typical when `${CAS_NAME}.${CAS_NAMESPACE}` resolves to an external CAS like `scone-cas.cf`), the second branch attests the public CAS directly.
+First, attest the CAS so the local SCONE CLI has the correct session encryption key. The kubectl path covers an in-cluster CAS; if it fails (typical when `${CAS_ENDPOINT}` points at an external CAS like `edge.scone-cas.cf`), the second branch attests the public CAS directly.
 
 ```bash
 # Attest the CAS instance before sending encrypted policies.
 kubectl scone cas attest --namespace ${CAS_NAMESPACE} ${CAS_NAME} -C -G -S \
-    || scone cas attest ${CAS_NAME}.${CAS_NAMESPACE} -C -G -S \
-        --only_for_testing-debug --only_for_testing-ignore-signer --only_for_testing-trust-any
+    || scone cas attest ${CAS_ENDPOINT} -C -G -S \
+        --only_for_testing-debug --only_for_testing-ignore-signer --only_for_testing-trust-any \
+    || echo "CAS attestation skipped: ${CAS_ENDPOINT} runs in simulation mode, so it cannot produce a DCAP quote"
 ```
 
 Then build the confidential image and generate the SCONE session from `manifests/scone.yaml`:
 
 ```bash
 # Generate the confidential image and sanitized manifest from the SCONE configuration.
-scone-td-build from -y manifests/scone.yaml
+scone-td-build apply -f manifests/scone.yaml
 ```
 
 This command:
@@ -190,7 +192,7 @@ kubectl apply -f manifests/manifest.prod.sanitized.yaml -n ${NAMESPACE}
 
 ```bash
 # Follow logs from the Kubernetes workload.
-retry-spinner -- kubectl logs deployment/java-args-env-file -n "${NAMESPACE}" --follow
+retry-spinner --retries 30 --wait 5 -- kubectl logs deployment/java-args-env-file -n "${NAMESPACE}" --follow
 ```
 
 ---

--- a/java-args-env-file/Values.yaml
+++ b/java-args-env-file/Values.yaml
@@ -8,6 +8,7 @@ environment:
   SCONE_VERSION: 6.1.0-rc.0
   CAS_NAMESPACE: default
   CAS_NAME: cas
-  CVM_MODE: 'true'
-  SCONE_ENCLAVE: 'true'
+  CAS_ENDPOINT: cas.default
+  TEE_TYPE: sgx
+  SCONE_ENCLAVE: 'false'
   NAMESPACE: java-demo

--- a/java-args-env-file/environment-variables.md
+++ b/java-args-env-file/environment-variables.md
@@ -8,10 +8,11 @@ This file defines the environment variables used to configure this `configmap` e
 4. The SCONE version is stored in `${SCONE_VERSION}`.
    The recommended value is `6.1.0-rc.0`.
 5. The CAS runs in Kubernetes namespace `${CAS_NAMESPACE}`.
-   The templates resolve `${CAS_NAME}.${CAS_NAMESPACE}` to the CAS endpoint, so for SCONE's public CAS at `scone-cas.cf` set `CAS_NAMESPACE=cf`.
+   `${CAS_NAME}` and `${CAS_NAMESPACE}` address the in-cluster CAS for `kubectl` calls.
 6. The CAS name is stored in `${CAS_NAME}`.
-   For SCONE's public CAS, set `CAS_NAME=scone-cas`.
-7. If you want to use CVM mode, set `${CVM_MODE}` to `true`. For SGX, set to `false`.
+   The manifests use `${CAS_ENDPOINT}` instead, which defaults to `cas.default`. Point it at
+   a public CAS to run against one, for example `CAS_ENDPOINT=edge.scone-cas.cf`.
+7. Set `${TEE_TYPE}` to `cvm` for CVM mode or `sgx` for SGX.
 8. In CVM mode, you can run on confidential Kubernetes nodes or Kata Pods.
    We recommend using confidential nodes and setting `${SCONE_ENCLAVE}` to `true`.
 9. We need to set the local signer: `${SIGNER}`

--- a/java-args-env-file/manifests/scone.template.yaml
+++ b/java-args-env-file/manifests/scone.template.yaml
@@ -3,14 +3,14 @@ kind: Register
 metadata:
   name: java-args-env-file-example
 spec:
-  protected_image: ${DEMO_IMAGE}
-  unprotected_image: ${DEMO_IMAGE}
-  destination_image: ${DESTINATION_IMAGE_NAME}
-  enforce: ["/opt/java/openjdk/bin/java"]
-  push_scone_image: true
-  version: ${SCONE_VERSION}
-  cvm: ${CVM_MODE}
-  manifest_env:
+  source-image: ${DEMO_IMAGE}
+  reference-image: ${DEMO_IMAGE}
+  output-image: ${DESTINATION_IMAGE_NAME}
+  protected-binaries: ["/opt/java/openjdk/bin/java"]
+  push-image: true
+  scone-version: ${SCONE_VERSION}
+  tee-type: ${TEE_TYPE}
+  container-env:
     - {name: SCONE_VERSION, value: "1"}
     - {name: SCONE_SYSLIBS, value: "1"}
     - {name: SCONE_PRODUCTION, value: "0"}
@@ -20,25 +20,25 @@ kind: Apply
 metadata:
   name: java-args-env-file-example
 spec:
-  version: ${SCONE_VERSION}
+  scone-version: ${SCONE_VERSION}
   # Inline‑selection: pick *only* the Deployment
   file:
     - "manifests/manifest.yaml"
-  output_manifest_file: "manifests/manifest.prod.sanitized.yaml"
-  output_session_file: "manifests/manifest.prod.session.yaml"
-  cas_address:
-    address: ${CAS_NAME}.${CAS_NAMESPACE}
-  manifest_env:
+  output-manifest: "manifests/manifest.prod.sanitized.yaml"
+  output-session: "manifests/manifest.prod.session.yaml"
+  cas-endpoint:
+    address: ${CAS_ENDPOINT}
+  container-env:
     - { name: SCONE_VERSION,  value: "1" }
     - { name: SCONE_LOG,      value: "WARNING" }
     - { name: SCONE_HEAP,     value: "6G" }
     - { name: SCONE_ALLOW_DLOPEN, value: "2" }
     - { name: SCONE_EDMM_MODE, value: "auto" }
     - { name: SCONE_SYSLIBS, value: "1" }
-  session_env:
+  cas-policy-env:
     - { name: LD_LIBRARY_PATH, value: /opt/java/openjdk/lib/server:/opt/java/openjdk/lib:/opt/java/openjdk/../lib }
     - { name: SCONE_METRICS, value: "prometheus_port:9999" }
   permissive: true
-  spol: true
-  cvm: ${CVM_MODE}
-  scone_enclave: ${SCONE_ENCLAVE}
+  encrypted-cas-policy: false
+  tee-type: ${TEE_TYPE}
+  scone-enclave: ${SCONE_ENCLAVE}

--- a/network-policy/README.md
+++ b/network-policy/README.md
@@ -70,7 +70,7 @@ tplenv --file "./manifest.template.yaml" --output "./manifest.yaml"
 # Render the template with the selected values.
 tplenv --file "./scone.template.yaml" --output "./scone.yaml" --indent
 # Generate the confidential image and sanitized manifest from the SCONE configuration.
-scone-td-build from -y ./scone.yaml
+scone-td-build apply -f ./scone.yaml
 ```
 
 Push the generated SCONE images:

--- a/network-policy/Values.yaml
+++ b/network-policy/Values.yaml
@@ -2,15 +2,12 @@ environment:
   IMAGE_PULL_SECRET_NAME: sconeapps
   CAS_NAMESPACE: default
   CAS_NAME: cas
+  CAS_ENDPOINT: cas.default
   SCONE_RUNTIME_VERSION: 6.1.0-rc.0
-  CVM_MODE: 'false'
+  TEE_TYPE: sgx
   SCONE_ENCLAVE: 'false'
   REGISTRY: registry.scontain.com
   NAMESPACE: default
-  CLIENT_IMAGE: registry.scontain.com/workshop/network-policy:client
-  SERVER_IMAGE: registry.scontain.com/workshop/network-policy:server
+  CLIENT_IMAGE: registry.scontain.com/k8s-scone-images/network-policy:client
+  SERVER_IMAGE: registry.scontain.com/k8s-scone-images/network-policy:server
   SCRIPT_DIR: .
-  SIGNER: |-
-    -----BEGIN PUBLIC KEY-----
-    MCowBQYDK2VwAyEAvSRST+dhEaX42c6VkY1Sv+KVelnSup96M6TMHOlqcrg=
-    -----END PUBLIC KEY-----

--- a/network-policy/environment-variables.md
+++ b/network-policy/environment-variables.md
@@ -10,10 +10,11 @@ This file defines the environment variables used to configure the `network-polic
 4. The SCONE version is stored in `${SCONE_RUNTIME_VERSION}`.
    The recommended value is `6.1.0-rc.0`.
 5. The CAS runs in Kubernetes namespace `${CAS_NAMESPACE}`.
-   The templates resolve `${CAS_NAME}.${CAS_NAMESPACE}` to the CAS endpoint, so for SCONE's public CAS at `scone-cas.cf` set `CAS_NAMESPACE=cf`.
+   `${CAS_NAME}` and `${CAS_NAMESPACE}` address the in-cluster CAS for `kubectl` calls.
 6. The CAS name is stored in `${CAS_NAME}`.
-   For SCONE's public CAS, set `CAS_NAME=scone-cas`.
-7. If you want to use CVM mode, set `${CVM_MODE}` to `true`. For SGX, set to `false`.
+   The manifests use `${CAS_ENDPOINT}` instead, which defaults to `cas.default`. Point it at
+   a public CAS to run against one, for example `CAS_ENDPOINT=edge.scone-cas.cf`.
+7. Set `${TEE_TYPE}` to `cvm` for CVM mode or `sgx` for SGX.
 8. In CVM mode, you can run on confidential Kubernetes nodes or Kata Pods.
    We recommend using confidential nodes and setting `${SCONE_ENCLAVE}` to `true`.
 9. The manifests are stored in `${SCRIPT_DIR}`

--- a/network-policy/scone.template.yaml
+++ b/network-policy/scone.template.yaml
@@ -3,13 +3,13 @@ kind: Register
 metadata:
   name: netshield
 spec:
-  protected_image: ${CLIENT_IMAGE}
-  unprotected_image: ${CLIENT_IMAGE}
-  enforce: ["/usr/local/bin/client-rust"]
-  push_scone_image: true
-  cvm: ${CVM_MODE}
-  version: ${SCONE_RUNTIME_VERSION}
-  manifest_env:
+  source-image: ${CLIENT_IMAGE}
+  reference-image: ${CLIENT_IMAGE}
+  protected-binaries: ["/usr/local/bin/client-rust"]
+  push-image: true
+  tee-type: ${TEE_TYPE}
+  scone-version: ${SCONE_RUNTIME_VERSION}
+  container-env:
     - {name: SCONE_VERSION, value: "1"}
     - {name: SCONE_SYSLIBS, value: "1"}
     - {name: SCONE_PRODUCTION, value: "0"}
@@ -20,13 +20,13 @@ kind: Register
 metadata:
   name: netshield
 spec:
-  protected_image: ${SERVER_IMAGE}
-  unprotected_image: ${SERVER_IMAGE}
-  enforce: ["/usr/local/bin/server-rust"]
-  push_scone_image: true
-  cvm: ${CVM_MODE}
-  version: ${SCONE_RUNTIME_VERSION}
-  manifest_env:
+  source-image: ${SERVER_IMAGE}
+  reference-image: ${SERVER_IMAGE}
+  protected-binaries: ["/usr/local/bin/server-rust"]
+  push-image: true
+  tee-type: ${TEE_TYPE}
+  scone-version: ${SCONE_RUNTIME_VERSION}
+  container-env:
     - {name: SCONE_VERSION, value: "1"}
     - {name: SCONE_SYSLIBS, value: "1"}
     - {name: SCONE_PRODUCTION, value: "0"}
@@ -39,22 +39,22 @@ metadata:
 spec:
   file:
     - "${SCRIPT_DIR}/manifest.yaml"
-  output_manifest_file: "${SCRIPT_DIR}/manifest.prod.sanitized.yaml"
-  output_session_file: "${SCRIPT_DIR}/manifest.prod.session.yaml"
-  cas_address:
-    address: ${CAS_NAME}.${CAS_NAMESPACE}
-  session_env:
+  output-manifest: "${SCRIPT_DIR}/manifest.prod.sanitized.yaml"
+  output-session: "${SCRIPT_DIR}/manifest.prod.session.yaml"
+  cas-endpoint:
+    address: ${CAS_ENDPOINT}
+  cas-policy-env:
     - {name: SCONE_VERSION, value: "1"}
-  manifest_env:
+  container-env:
     - {name: SCONE_VERSION, value: "1"}
     - {name: SCONE_SYSLIBS, value: "1"}
     - {name: SCONE_PRODUCTION, value: "0"}
     - {name: SCONE_HEAP, value: "2G"}
   permissive: true
-  spol: true
-  cvm: ${CVM_MODE}
-  scone_enclave: ${SCONE_ENCLAVE}
-  version: ${SCONE_RUNTIME_VERSION}
+  encrypted-cas-policy: false
+  tee-type: ${TEE_TYPE}
+  scone-enclave: ${SCONE_ENCLAVE}
+  scone-version: ${SCONE_RUNTIME_VERSION}
   access_policy:
     read:
       - ANY

--- a/scripts/configmap.sh
+++ b/scripts/configmap.sh
@@ -118,8 +118,9 @@ printf '%s\n' '- `$IMAGE_PULL_SECRET_NAME` - Pull secret name (default: `sconeap
 printf '%s\n' '- `$SCONE_RUNTIME_VERSION` - SCONE version to use (for example, `6.1.0-rc.0`)'
 printf '%s\n' '- `$CAS_NAMESPACE` - CAS namespace (for example, `default`)'
 printf '%s\n' '- `$CAS_NAME` - CAS name (for example, `cas`)'
-printf '%s\n' '- `$CVM_MODE` - Set to `--cvm` for CVM mode, otherwise leave empty for SGX'
-printf '%s\n' '- `$SCONE_ENCLAVE` - In CVM mode, set to `--scone-enclave` for confidential nodes, or leave empty for Kata Pods'
+printf '%s\n' '- `$CAS_ENDPOINT` - Address the manifest targets; keep it in sync with `$CAS_NAME`.`$CAS_NAMESPACE` (default: `cas.default`), or set to an external CAS address to run against one'
+printf '%s\n' '- `$TEE_TYPE` - Set to `cvm` for CVM mode or `sgx` for SGX'
+printf '%s\n' '- `$SCONE_ENCLAVE` - In CVM mode, set to `true` for confidential nodes, or `false` for Kata Pods'
 printf '%s\n' '- `$NAMESPACE` - Kubernetes namespace where the demo runs (default: `default`)'
 printf '%s\n' ''
 printf '%s\n' 'Set `SIGNER` for policy signing:'
@@ -258,9 +259,9 @@ printf "${ORANGE}"
 printf '%s\n' '# Apply the Kubernetes manifest.'
 printf '%s\n' 'kubectl apply -f manifests/manifest.yaml -n ${NAMESPACE}'
 printf '%s\n' '# Retry the wrapped command until it succeeds or reaches the retry limit.'
-printf '%s\n' 'retry-spinner --retries 5 --wait 2 -- kubectl logs job/my-rust-app -n ${NAMESPACE} -c reader-1'
+printf '%s\n' 'retry-spinner --retries 30 --wait 5 -- kubectl logs job/my-rust-app -n ${NAMESPACE} -c reader-1'
 printf '%s\n' '# Retry the wrapped command until it succeeds or reaches the retry limit.'
-printf '%s\n' 'retry-spinner --retries 5 --wait 2 -- kubectl logs job/my-rust-app -n ${NAMESPACE} -c reader-2'
+printf '%s\n' 'retry-spinner --retries 30 --wait 5 -- kubectl logs job/my-rust-app -n ${NAMESPACE} -c reader-2'
 printf '%s\n' ''
 printf '%s\n' '# Clean up native app'
 printf '%s\n' '# Delete the Kubernetes resource if it exists.'
@@ -270,9 +271,9 @@ printf "${RESET}"
 # Apply the Kubernetes manifest.
 kubectl apply -f manifests/manifest.yaml -n ${NAMESPACE}
 # Retry the wrapped command until it succeeds or reaches the retry limit.
-retry-spinner --retries 5 --wait 2 -- kubectl logs job/my-rust-app -n ${NAMESPACE} -c reader-1
+retry-spinner --retries 30 --wait 5 -- kubectl logs job/my-rust-app -n ${NAMESPACE} -c reader-1
 # Retry the wrapped command until it succeeds or reaches the retry limit.
-retry-spinner --retries 5 --wait 2 -- kubectl logs job/my-rust-app -n ${NAMESPACE} -c reader-2
+retry-spinner --retries 30 --wait 5 -- kubectl logs job/my-rust-app -n ${NAMESPACE} -c reader-2
 
 # Clean up native app
 # Delete the Kubernetes resource if it exists.
@@ -284,21 +285,23 @@ printf '%s\n' 'Your containers should print content from the mounted ConfigMap f
 printf '%s\n' ''
 printf '%s\n' '## 8. Prepare and Apply the SCONE Manifest'
 printf '%s\n' ''
-printf '%s\n' 'First, attest the CAS so the local SCONE CLI has the correct session encryption key. The kubectl path covers an in-cluster CAS; if it fails (typical when `${CAS_NAME}.${CAS_NAMESPACE}` resolves to an external CAS like `scone-cas.cf`), the second branch attests the public CAS directly.'
+printf '%s\n' 'First, attest the CAS so the local SCONE CLI has the correct session encryption key. The kubectl path covers an in-cluster CAS; if it fails (typical when `${CAS_ENDPOINT}` points at an external CAS like `edge.scone-cas.cf`), the second branch attests the public CAS directly.'
 printf '%s\n' ''
 printf "${RESET}"
 
 printf "${ORANGE}"
 printf '%s\n' '# Attest the CAS instance before sending encrypted policies.'
 printf '%s\n' 'kubectl scone cas attest --namespace ${CAS_NAMESPACE} ${CAS_NAME} -C -G -S \'
-printf '%s\n' '    || scone cas attest ${CAS_NAME}.${CAS_NAMESPACE} -C -G -S \'
-printf '%s\n' '        --only_for_testing-debug --only_for_testing-ignore-signer --only_for_testing-trust-any'
+printf '%s\n' '    || scone cas attest ${CAS_ENDPOINT} -C -G -S \'
+printf '%s\n' '        --only_for_testing-debug --only_for_testing-ignore-signer --only_for_testing-trust-any \'
+printf '%s\n' '    || echo "CAS attestation skipped: ${CAS_ENDPOINT} runs in simulation mode, so it cannot produce a DCAP quote"'
 printf "${RESET}"
 
 # Attest the CAS instance before sending encrypted policies.
 kubectl scone cas attest --namespace ${CAS_NAMESPACE} ${CAS_NAME} -C -G -S \
-    || scone cas attest ${CAS_NAME}.${CAS_NAMESPACE} -C -G -S \
-        --only_for_testing-debug --only_for_testing-ignore-signer --only_for_testing-trust-any
+    || scone cas attest ${CAS_ENDPOINT} -C -G -S \
+        --only_for_testing-debug --only_for_testing-ignore-signer --only_for_testing-trust-any \
+    || echo "CAS attestation skipped: ${CAS_ENDPOINT} runs in simulation mode, so it cannot produce a DCAP quote"
 
 printf "${VIOLET}"
 printf '%s\n' ''
@@ -306,11 +309,11 @@ printf "${RESET}"
 
 printf "${ORANGE}"
 printf '%s\n' '# Generate the confidential image and sanitized manifest from the SCONE configuration.'
-printf '%s\n' 'scone-td-build from -y manifests/scone.yaml'
+printf '%s\n' 'scone-td-build apply -f manifests/scone.yaml'
 printf "${RESET}"
 
 # Generate the confidential image and sanitized manifest from the SCONE configuration.
-scone-td-build from -y manifests/scone.yaml
+scone-td-build apply -f manifests/scone.yaml
 
 printf "${VIOLET}"
 printf '%s\n' ''
@@ -340,15 +343,15 @@ printf "${RESET}"
 
 printf "${ORANGE}"
 printf '%s\n' '# Retry the wrapped command until it succeeds or reaches the retry limit.'
-printf '%s\n' 'retry-spinner -- kubectl logs job/my-rust-app -n ${NAMESPACE} -c reader-1 --follow'
+printf '%s\n' 'retry-spinner --retries 30 --wait 5 -- kubectl logs job/my-rust-app -n ${NAMESPACE} -c reader-1 --follow'
 printf '%s\n' '# Retry the wrapped command until it succeeds or reaches the retry limit.'
-printf '%s\n' 'retry-spinner -- kubectl logs job/my-rust-app -n ${NAMESPACE} -c reader-2 --follow'
+printf '%s\n' 'retry-spinner --retries 30 --wait 5 -- kubectl logs job/my-rust-app -n ${NAMESPACE} -c reader-2 --follow'
 printf "${RESET}"
 
 # Retry the wrapped command until it succeeds or reaches the retry limit.
-retry-spinner -- kubectl logs job/my-rust-app -n ${NAMESPACE} -c reader-1 --follow
+retry-spinner --retries 30 --wait 5 -- kubectl logs job/my-rust-app -n ${NAMESPACE} -c reader-1 --follow
 # Retry the wrapped command until it succeeds or reaches the retry limit.
-retry-spinner -- kubectl logs job/my-rust-app -n ${NAMESPACE} -c reader-2 --follow
+retry-spinner --retries 30 --wait 5 -- kubectl logs job/my-rust-app -n ${NAMESPACE} -c reader-2 --follow
 
 printf "${VIOLET}"
 printf '%s\n' ''

--- a/scripts/flask-redis-netshield.sh
+++ b/scripts/flask-redis-netshield.sh
@@ -625,7 +625,7 @@ printf '%s\n' 'tplenv --file scone.template.yaml --create-values-file --output s
 printf '%s\n' '# Remove `flask-redis-demo.json` if it exists.'
 printf '%s\n' 'rm flask-redis-demo.json || true'
 printf '%s\n' '# Generate the confidential image and sanitized manifest from the SCONE configuration.'
-printf '%s\n' 'scone-td-build from -y scone.yaml'
+printf '%s\n' 'scone-td-build apply -f scone.yaml'
 printf '%s\n' '# Use the registry-backed Redis SCONE image that the Register step pushed.'
 printf '%s\n' 'if grep -q '\''image: redis:7-bookworm-scone'\'' manifest.prod.sanitized.yaml; then'
 printf '%s\n' '  sed -i.bak "s|image: redis:7-bookworm-scone|image: ${IMAGE_NAME}-redis-scone|g" manifest.prod.sanitized.yaml'
@@ -638,7 +638,7 @@ tplenv --file scone.template.yaml --create-values-file --output scone.yaml --ind
 # Remove `flask-redis-demo.json` if it exists.
 rm flask-redis-demo.json || true
 # Generate the confidential image and sanitized manifest from the SCONE configuration.
-scone-td-build from -y scone.yaml
+scone-td-build apply -f scone.yaml
 # Use the registry-backed Redis SCONE image that the Register step pushed.
 if grep -q 'image: redis:7-bookworm-scone' manifest.prod.sanitized.yaml; then
   sed -i.bak "s|image: redis:7-bookworm-scone|image: ${IMAGE_NAME}-redis-scone|g" manifest.prod.sanitized.yaml

--- a/scripts/flask-redis.sh
+++ b/scripts/flask-redis.sh
@@ -658,7 +658,7 @@ printf '%s\n' 'tplenv --file scone.template.yaml --create-values-file --output s
 printf '%s\n' '# Remove `flask-redis-demo.json` if it exists.'
 printf '%s\n' 'rm flask-redis-demo.json || true'
 printf '%s\n' '# Generate the confidential image and sanitized manifest from the SCONE configuration.'
-printf '%s\n' 'scone-td-build from -y scone.yaml'
+printf '%s\n' 'scone-td-build apply -f scone.yaml'
 printf '%s\n' '# Use the registry-backed Redis SCONE image that the Register step pushed.'
 printf '%s\n' 'if grep -q '\''image: redis:7-bookworm-scone'\'' manifest.prod.sanitized.yaml; then'
 printf '%s\n' '  sed -i.bak "s|image: redis:7-bookworm-scone|image: ${IMAGE_NAME}-redis-scone|g" manifest.prod.sanitized.yaml'
@@ -671,7 +671,7 @@ tplenv --file scone.template.yaml --create-values-file --output scone.yaml --ind
 # Remove `flask-redis-demo.json` if it exists.
 rm flask-redis-demo.json || true
 # Generate the confidential image and sanitized manifest from the SCONE configuration.
-scone-td-build from -y scone.yaml
+scone-td-build apply -f scone.yaml
 # Use the registry-backed Redis SCONE image that the Register step pushed.
 if grep -q 'image: redis:7-bookworm-scone' manifest.prod.sanitized.yaml; then
   sed -i.bak "s|image: redis:7-bookworm-scone|image: ${IMAGE_NAME}-redis-scone|g" manifest.prod.sanitized.yaml

--- a/scripts/go-args-env-file.sh
+++ b/scripts/go-args-env-file.sh
@@ -136,8 +136,9 @@ printf '%s\n' '- `$IMAGE_PULL_SECRET_NAME` — Pull secret name (default: `scone
 printf '%s\n' '- `$SCONE_RUNTIME_VERSION` — SCONE version to use (for example, `6.1.0-rc.0`)'
 printf '%s\n' '- `$CAS_NAMESPACE` — CAS namespace (for example, `default`)'
 printf '%s\n' '- `$CAS_NAME` — CAS name (for example, `cas`)'
-printf '%s\n' '- `$CVM_MODE` — Set to `--cvm` for CVM mode, otherwise leave empty for SGX'
-printf '%s\n' '- `$SCONE_ENCLAVE` — In CVM mode, set to `--scone-enclave` for confidential nodes, or leave empty for Kata Pods'
+printf '%s\n' '- `$CAS_ENDPOINT` - Address the manifest targets; keep it in sync with `$CAS_NAME`.`$CAS_NAMESPACE` (default: `cas.default`), or set to an external CAS address to run against one'
+printf '%s\n' '- `$TEE_TYPE` — Set to `cvm` for CVM mode or `sgx` for SGX'
+printf '%s\n' '- `$SCONE_ENCLAVE` - In CVM mode, set to `true` for confidential nodes, or `false` for Kata Pods'
 printf '%s\n' '- `$NAMESPACE` — Kubernetes namespace where the demo runs (default: `default`)'
 printf '%s\n' ''
 printf '%s\n' 'Set `SIGNER` for policy signing:'
@@ -339,21 +340,23 @@ printf '%s\n' '---'
 printf '%s\n' ''
 printf '%s\n' '## 8. Prepare and Apply the SCONE Manifest'
 printf '%s\n' ''
-printf '%s\n' 'First, attest the CAS so the local SCONE CLI has the correct session encryption key. The kubectl path covers an in-cluster CAS; if it fails (typical when `${CAS_NAME}.${CAS_NAMESPACE}` resolves to an external CAS like `scone-cas.cf`), the second branch attests the public CAS directly.'
+printf '%s\n' 'First, attest the CAS so the local SCONE CLI has the correct session encryption key. The kubectl path covers an in-cluster CAS; if it fails (typical when `${CAS_ENDPOINT}` points at an external CAS like `edge.scone-cas.cf`), the second branch attests the public CAS directly.'
 printf '%s\n' ''
 printf "${RESET}"
 
 printf "${ORANGE}"
 printf '%s\n' '# Attest the CAS instance before sending encrypted policies.'
 printf '%s\n' 'kubectl scone cas attest --namespace ${CAS_NAMESPACE} ${CAS_NAME} -C -G -S \'
-printf '%s\n' '    || scone cas attest ${CAS_NAME}.${CAS_NAMESPACE} -C -G -S \'
-printf '%s\n' '        --only_for_testing-debug --only_for_testing-ignore-signer --only_for_testing-trust-any'
+printf '%s\n' '    || scone cas attest ${CAS_ENDPOINT} -C -G -S \'
+printf '%s\n' '        --only_for_testing-debug --only_for_testing-ignore-signer --only_for_testing-trust-any \'
+printf '%s\n' '    || echo "CAS attestation skipped: ${CAS_ENDPOINT} runs in simulation mode, so it cannot produce a DCAP quote"'
 printf "${RESET}"
 
 # Attest the CAS instance before sending encrypted policies.
 kubectl scone cas attest --namespace ${CAS_NAMESPACE} ${CAS_NAME} -C -G -S \
-    || scone cas attest ${CAS_NAME}.${CAS_NAMESPACE} -C -G -S \
-        --only_for_testing-debug --only_for_testing-ignore-signer --only_for_testing-trust-any
+    || scone cas attest ${CAS_ENDPOINT} -C -G -S \
+        --only_for_testing-debug --only_for_testing-ignore-signer --only_for_testing-trust-any \
+    || echo "CAS attestation skipped: ${CAS_ENDPOINT} runs in simulation mode, so it cannot produce a DCAP quote"
 
 printf "${VIOLET}"
 printf '%s\n' ''
@@ -363,11 +366,11 @@ printf "${RESET}"
 
 printf "${ORANGE}"
 printf '%s\n' '# Generate the confidential image and sanitized manifest from the SCONE configuration.'
-printf '%s\n' 'scone-td-build from -y manifests/scone.yaml'
+printf '%s\n' 'scone-td-build apply -f manifests/scone.yaml'
 printf "${RESET}"
 
 # Generate the confidential image and sanitized manifest from the SCONE configuration.
-scone-td-build from -y manifests/scone.yaml
+scone-td-build apply -f manifests/scone.yaml
 
 printf "${VIOLET}"
 printf '%s\n' ''

--- a/scripts/hello-world.sh
+++ b/scripts/hello-world.sh
@@ -123,8 +123,9 @@ printf '%s\n' '- `$DESTINATION_IMAGE_NAME` - Name of the confidential image'
 printf '%s\n' '- `$SCONE_VERSION` - SCONE version to use (for example, `6.1.0-rc.0`)'
 printf '%s\n' '- `$CAS_NAMESPACE` - CAS Kubernetes namespace (for example, `default`)'
 printf '%s\n' '- `$CAS_NAME` - CAS Kubernetes name (for example, `cas`)'
-printf '%s\n' '- `$CVM_MODE` - Set to `--cvm` for CVM mode, otherwise leave empty for SGX'
-printf '%s\n' '- `$SCONE_ENCLAVE` - In CVM mode, set to `--scone-enclave` for confidential nodes, or leave empty for Kata Pods'
+printf '%s\n' '- `$CAS_ENDPOINT` - Address the manifest targets; keep it in sync with `$CAS_NAME`.`$CAS_NAMESPACE` (default: `cas.default`), or set to an external CAS address to run against one'
+printf '%s\n' '- `$TEE_TYPE` - Set to `cvm` for CVM mode or `sgx` for SGX'
+printf '%s\n' '- `$SCONE_ENCLAVE` - In CVM mode, set to `true` for confidential nodes, or `false` for Kata Pods'
 printf '%s\n' '- `$NAMESPACE` - Kubernetes namespace where the demo runs (default: `default`)'
 printf '%s\n' ''
 printf '%s\n' 'Defaults are stored in `Values.yaml`. We use [`tplenv`](https://github.com/scontainug/tplenv) to confirm or override values:'
@@ -160,10 +161,14 @@ printf "${RESET}"
 printf "${ORANGE}"
 printf '%s\n' '# Render the template with the selected values.'
 printf '%s\n' 'tplenv --file manifest.job.template.yaml --create-values-file --output manifest.job.yaml'
+printf '%s\n' '# Render the SCONE manifest that drives register plus apply.'
+printf '%s\n' 'tplenv --file scone.template.yaml --create-values-file --output scone.yaml --indent'
 printf "${RESET}"
 
 # Render the template with the selected values.
 tplenv --file manifest.job.template.yaml --create-values-file --output manifest.job.yaml
+# Render the SCONE manifest that drives register plus apply.
+tplenv --file scone.template.yaml --create-values-file --output scone.yaml --indent
 
 printf "${VIOLET}"
 printf '%s\n' ''
@@ -345,21 +350,23 @@ printf "${VIOLET}"
 printf '%s\n' ''
 printf '%s\n' '## 6. Attest SCONE CAS'
 printf '%s\n' ''
-printf '%s\n' 'Attest CAS before sending encrypted policies. The kubectl path covers in-cluster CAS; if it fails (typical when `${CAS_NAME}.${CAS_NAMESPACE}` resolves to an external CAS like `scone-cas.cf`), the second branch attests the public CAS directly.'
+printf '%s\n' 'Attest CAS before sending encrypted policies. The kubectl path covers in-cluster CAS; if it fails (typical when `${CAS_ENDPOINT}` points at an external CAS like `edge.scone-cas.cf`), the second branch attests the public CAS directly.'
 printf '%s\n' ''
 printf "${RESET}"
 
 printf "${ORANGE}"
 printf '%s\n' '# Attest the CAS instance before sending encrypted policies.'
 printf '%s\n' 'kubectl scone cas attest --namespace ${CAS_NAMESPACE} ${CAS_NAME} -C -G -S \'
-printf '%s\n' '    || scone cas attest ${CAS_NAME}.${CAS_NAMESPACE} -C -G -S \'
-printf '%s\n' '        --only_for_testing-debug --only_for_testing-ignore-signer --only_for_testing-trust-any'
+printf '%s\n' '    || scone cas attest ${CAS_ENDPOINT} -C -G -S \'
+printf '%s\n' '        --only_for_testing-debug --only_for_testing-ignore-signer --only_for_testing-trust-any \'
+printf '%s\n' '    || echo "CAS attestation skipped: ${CAS_ENDPOINT} runs in simulation mode, so it cannot produce a DCAP quote"'
 printf "${RESET}"
 
 # Attest the CAS instance before sending encrypted policies.
 kubectl scone cas attest --namespace ${CAS_NAMESPACE} ${CAS_NAME} -C -G -S \
-    || scone cas attest ${CAS_NAME}.${CAS_NAMESPACE} -C -G -S \
-        --only_for_testing-debug --only_for_testing-ignore-signer --only_for_testing-trust-any
+    || scone cas attest ${CAS_ENDPOINT} -C -G -S \
+        --only_for_testing-debug --only_for_testing-ignore-signer --only_for_testing-trust-any \
+    || echo "CAS attestation skipped: ${CAS_ENDPOINT} runs in simulation mode, so it cannot produce a DCAP quote"
 
 printf "${VIOLET}"
 printf '%s\n' ''
@@ -367,37 +374,29 @@ printf '%s\n' 'If attestation fails, inspect the command output for detected vul
 printf '%s\n' ''
 printf '%s\n' '## 7. Register the Confidential Image'
 printf '%s\n' ''
-printf '%s\n' 'Register the image for confidential execution:'
+printf '%s\n' '`scone.yaml` holds both documents: the `Register` that produces the protected image and'
+printf '%s\n' 'the `Apply` that turns `manifest.job.yaml` into a sanitized confidential manifest. A'
+printf '%s\n' 'single command runs both:'
 printf '%s\n' ''
 printf "${RESET}"
 
 printf "${ORANGE}"
-printf '%s\n' '# Register the image for confidential execution.'
-printf '%s\n' 'scone-td-build register --protected-image $IMAGE_NAME --unprotected-image rust:latest --manifest-env SCONE_PRODUCTION=0 -s ./storage.json --destination-image ${DESTINATION_IMAGE_NAME} --push --version ${SCONE_RUNTIME_VERSION} ${CVM_MODE}'
+printf '%s\n' '# Register the image and transform the manifest in one step.'
+printf '%s\n' 'scone-td-build apply -f scone.yaml'
 printf "${RESET}"
 
-# Register the image for confidential execution.
-scone-td-build register --protected-image $IMAGE_NAME --unprotected-image rust:latest --manifest-env SCONE_PRODUCTION=0 -s ./storage.json --destination-image ${DESTINATION_IMAGE_NAME} --push --version ${SCONE_RUNTIME_VERSION} ${CVM_MODE}
+# Register the image and transform the manifest in one step.
+scone-td-build apply -f scone.yaml
 
 printf "${VIOLET}"
 printf '%s\n' ''
-printf '%s\n' 'This creates a protected image (or uses `--destination-image` if provided) and decouples your deployment from upstream image changes.'
+printf '%s\n' 'This creates a protected image (or uses `output-image` if provided) and decouples your'
+printf '%s\n' 'deployment from upstream image changes.'
 printf '%s\n' ''
 printf '%s\n' '## 8. Transform the Kubernetes Manifest'
 printf '%s\n' ''
-printf '%s\n' 'Convert the native manifest into a sanitized confidential manifest:'
-printf '%s\n' ''
-printf "${RESET}"
-
-printf "${ORANGE}"
-printf '%s\n' '# Convert the native manifest into a confidential manifest.'
-printf '%s\n' 'scone-td-build apply -f manifest.job.yaml -c ${CAS_NAME}.${CAS_NAMESPACE} -p -s ./storage.json --manifest-env SCONE_SYSLIBS=1 --manifest-env SCONE_PRODUCTION=0 --manifest-env SCONE_HEAP=1G --spol --manifest-env SCONE_VERSION=1 --output-manifest-file manifest.job.sanitized.yaml --version ${SCONE_RUNTIME_VERSION} ${CVM_MODE} ${SCONE_ENCLAVE}'
-printf "${RESET}"
-
-# Convert the native manifest into a confidential manifest.
-scone-td-build apply -f manifest.job.yaml -c ${CAS_NAME}.${CAS_NAMESPACE} -p -s ./storage.json --manifest-env SCONE_SYSLIBS=1 --manifest-env SCONE_PRODUCTION=0 --manifest-env SCONE_HEAP=1G --spol --manifest-env SCONE_VERSION=1 --output-manifest-file manifest.job.sanitized.yaml --version ${SCONE_RUNTIME_VERSION} ${CVM_MODE} ${SCONE_ENCLAVE}
-
-printf "${VIOLET}"
+printf '%s\n' 'The previous step already wrote `manifest.job.sanitized.yaml`, the confidential manifest'
+printf '%s\n' 'declared as `output-manifest` in `scone.yaml`.'
 printf '%s\n' ''
 printf '%s\n' '## 9. Deploy the Confidential Manifest'
 printf '%s\n' ''

--- a/scripts/java-args-env-file.sh
+++ b/scripts/java-args-env-file.sh
@@ -121,8 +121,9 @@ printf '%s\n' '- `$IMAGE_PULL_SECRET_NAME` — Pull secret name (default: `scone
 printf '%s\n' '- `$SCONE_VERSION` — SCONE version to use (for example, `6.1.0-rc.0`)'
 printf '%s\n' '- `$CAS_NAMESPACE` — CAS namespace (for example, `default`)'
 printf '%s\n' '- `$CAS_NAME` — CAS name (for example, `cas`)'
-printf '%s\n' '- `$CVM_MODE` — Set to `--cvm` for CVM mode, otherwise leave empty for SGX'
-printf '%s\n' '- `$SCONE_ENCLAVE` — In CVM mode, set to `--scone-enclave` for confidential nodes, or leave empty for Kata Pods'
+printf '%s\n' '- `$CAS_ENDPOINT` - Address the manifest targets; keep it in sync with `$CAS_NAME`.`$CAS_NAMESPACE` (default: `cas.default`), or set to an external CAS address to run against one'
+printf '%s\n' '- `$TEE_TYPE` — Set to `cvm` for CVM mode or `sgx` for SGX'
+printf '%s\n' '- `$SCONE_ENCLAVE` - In CVM mode, set to `true` for confidential nodes, or `false` for Kata Pods'
 printf '%s\n' '- `$NAMESPACE` — namespace name (for example, `java-demo`)'
 printf '%s\n' ''
 printf '%s\n' 'Assume you start in `scone-td-build-demos` and switch into this demo directory:'
@@ -255,13 +256,13 @@ printf "${ORANGE}"
 printf '%s\n' '# Apply the Kubernetes manifest.'
 printf '%s\n' 'kubectl apply -f manifests/manifest.yaml -n ${NAMESPACE}'
 printf '%s\n' '# Follow logs from the Kubernetes workload.'
-printf '%s\n' 'retry-spinner --retries 10 --wait 2 -- kubectl logs deployment/java-args-env-file -n "${NAMESPACE}" --follow'
+printf '%s\n' 'retry-spinner --retries 30 --wait 5 -- kubectl logs deployment/java-args-env-file -n "${NAMESPACE}" --follow'
 printf "${RESET}"
 
 # Apply the Kubernetes manifest.
 kubectl apply -f manifests/manifest.yaml -n ${NAMESPACE}
 # Follow logs from the Kubernetes workload.
-retry-spinner --retries 10 --wait 2 -- kubectl logs deployment/java-args-env-file -n "${NAMESPACE}" --follow
+retry-spinner --retries 30 --wait 5 -- kubectl logs deployment/java-args-env-file -n "${NAMESPACE}" --follow
 
 printf "${VIOLET}"
 printf '%s\n' ''
@@ -289,21 +290,23 @@ printf '%s\n' '---'
 printf '%s\n' ''
 printf '%s\n' '## 8. Prepare and Apply the SCONE Manifest'
 printf '%s\n' ''
-printf '%s\n' 'First, attest the CAS so the local SCONE CLI has the correct session encryption key. The kubectl path covers an in-cluster CAS; if it fails (typical when `${CAS_NAME}.${CAS_NAMESPACE}` resolves to an external CAS like `scone-cas.cf`), the second branch attests the public CAS directly.'
+printf '%s\n' 'First, attest the CAS so the local SCONE CLI has the correct session encryption key. The kubectl path covers an in-cluster CAS; if it fails (typical when `${CAS_ENDPOINT}` points at an external CAS like `edge.scone-cas.cf`), the second branch attests the public CAS directly.'
 printf '%s\n' ''
 printf "${RESET}"
 
 printf "${ORANGE}"
 printf '%s\n' '# Attest the CAS instance before sending encrypted policies.'
 printf '%s\n' 'kubectl scone cas attest --namespace ${CAS_NAMESPACE} ${CAS_NAME} -C -G -S \'
-printf '%s\n' '    || scone cas attest ${CAS_NAME}.${CAS_NAMESPACE} -C -G -S \'
-printf '%s\n' '        --only_for_testing-debug --only_for_testing-ignore-signer --only_for_testing-trust-any'
+printf '%s\n' '    || scone cas attest ${CAS_ENDPOINT} -C -G -S \'
+printf '%s\n' '        --only_for_testing-debug --only_for_testing-ignore-signer --only_for_testing-trust-any \'
+printf '%s\n' '    || echo "CAS attestation skipped: ${CAS_ENDPOINT} runs in simulation mode, so it cannot produce a DCAP quote"'
 printf "${RESET}"
 
 # Attest the CAS instance before sending encrypted policies.
 kubectl scone cas attest --namespace ${CAS_NAMESPACE} ${CAS_NAME} -C -G -S \
-    || scone cas attest ${CAS_NAME}.${CAS_NAMESPACE} -C -G -S \
-        --only_for_testing-debug --only_for_testing-ignore-signer --only_for_testing-trust-any
+    || scone cas attest ${CAS_ENDPOINT} -C -G -S \
+        --only_for_testing-debug --only_for_testing-ignore-signer --only_for_testing-trust-any \
+    || echo "CAS attestation skipped: ${CAS_ENDPOINT} runs in simulation mode, so it cannot produce a DCAP quote"
 
 printf "${VIOLET}"
 printf '%s\n' ''
@@ -313,11 +316,11 @@ printf "${RESET}"
 
 printf "${ORANGE}"
 printf '%s\n' '# Generate the confidential image and sanitized manifest from the SCONE configuration.'
-printf '%s\n' 'scone-td-build from -y manifests/scone.yaml'
+printf '%s\n' 'scone-td-build apply -f manifests/scone.yaml'
 printf "${RESET}"
 
 # Generate the confidential image and sanitized manifest from the SCONE configuration.
-scone-td-build from -y manifests/scone.yaml
+scone-td-build apply -f manifests/scone.yaml
 
 printf "${VIOLET}"
 printf '%s\n' ''
@@ -351,11 +354,11 @@ printf "${RESET}"
 
 printf "${ORANGE}"
 printf '%s\n' '# Follow logs from the Kubernetes workload.'
-printf '%s\n' 'retry-spinner -- kubectl logs deployment/java-args-env-file -n "${NAMESPACE}" --follow'
+printf '%s\n' 'retry-spinner --retries 30 --wait 5 -- kubectl logs deployment/java-args-env-file -n "${NAMESPACE}" --follow'
 printf "${RESET}"
 
 # Follow logs from the Kubernetes workload.
-retry-spinner -- kubectl logs deployment/java-args-env-file -n "${NAMESPACE}" --follow
+retry-spinner --retries 30 --wait 5 -- kubectl logs deployment/java-args-env-file -n "${NAMESPACE}" --follow
 
 printf "${VIOLET}"
 printf '%s\n' ''

--- a/scripts/network-policy.sh
+++ b/scripts/network-policy.sh
@@ -189,7 +189,7 @@ printf '%s\n' 'tplenv --file "./manifest.template.yaml" --output "./manifest.yam
 printf '%s\n' '# Render the template with the selected values.'
 printf '%s\n' 'tplenv --file "./scone.template.yaml" --output "./scone.yaml" --indent'
 printf '%s\n' '# Generate the confidential image and sanitized manifest from the SCONE configuration.'
-printf '%s\n' 'scone-td-build from -y ./scone.yaml'
+printf '%s\n' 'scone-td-build apply -f ./scone.yaml'
 printf "${RESET}"
 
 # Render the template with the selected values.
@@ -197,7 +197,7 @@ tplenv --file "./manifest.template.yaml" --output "./manifest.yaml"
 # Render the template with the selected values.
 tplenv --file "./scone.template.yaml" --output "./scone.yaml" --indent
 # Generate the confidential image and sanitized manifest from the SCONE configuration.
-scone-td-build from -y ./scone.yaml
+scone-td-build apply -f ./scone.yaml
 
 printf "${VIOLET}"
 printf '%s\n' ''

--- a/scripts/prepare-example-ci.sh
+++ b/scripts/prepare-example-ci.sh
@@ -175,45 +175,25 @@ all_values_files=(
   "${repo_root}/image-signing/Values.yaml"
 )
 
+# tee-type replaced the old cvm boolean, so the migrated demos consume SCONE_ENCLAVE as a
+# boolean value. image-signing (added upstream) still ships the flag-style SCONE_ENCLAVE,
+# so it is overridden after the shared loop below.
 flag_mode_files=(
-  "${repo_root}/hello-world/Values.yaml"
-  "${repo_root}/web-server/Values.yaml"
   "${repo_root}/image-signing/Values.yaml"
 )
-
-boolean_mode_files=(
-  "${repo_root}/configmap/Values.yaml"
-  "${repo_root}/network-policy/Values.yaml"
-  "${repo_root}/go-args-env-file/Values.yaml"
-  "${repo_root}/flask-redis/Values.yaml"
-  "${repo_root}/flask-redis-netshield/Values.yaml"
-  "${repo_root}/java-args-env-file/Values.yaml"
-  "${repo_root}/software-updates/Values.yaml"
-)
-
 if [[ "$mode" == "sgx" ]]; then
-  flag_cvm_mode="''"
+  tee_type="sgx"
+  scone_enclave="'false'"
   flag_scone_enclave="''"
-  boolean_cvm_mode="'false'"
-  boolean_scone_enclave="'false'"
 else
-  flag_cvm_mode="--cvm"
+  tee_type="cvm"
+  scone_enclave="'true'"
   flag_scone_enclave="--scone-enclave"
-  boolean_cvm_mode="'true'"
-  boolean_scone_enclave="'true'"
 fi
 
-for values_file in "${flag_mode_files[@]}"; do
-  upsert_scalar "$values_file" "CVM_MODE" "$flag_cvm_mode"
-  upsert_scalar "$values_file" "SCONE_ENCLAVE" "$flag_scone_enclave"
-done
-
-for values_file in "${boolean_mode_files[@]}"; do
-  upsert_scalar "$values_file" "CVM_MODE" "$boolean_cvm_mode"
-  upsert_scalar "$values_file" "SCONE_ENCLAVE" "$boolean_scone_enclave"
-done
-
 for values_file in "${all_values_files[@]}"; do
+  upsert_scalar "$values_file" "TEE_TYPE" "$tee_type"
+  upsert_scalar "$values_file" "SCONE_ENCLAVE" "$scone_enclave"
   upsert_scalar "$values_file" "IMAGE_PULL_SECRET_NAME" "$image_pull_secret_name"
   upsert_scalar "$values_file" "REGISTRY" "$registry"
   if [[ -n "$namespace" ]]; then
@@ -225,6 +205,24 @@ for values_file in "${all_values_files[@]}"; do
   if [[ -n "${CAS_NAMESPACE:-}" ]]; then
     upsert_scalar "$values_file" "CAS_NAMESPACE" "$CAS_NAMESPACE"
   fi
+  # CAS_ENDPOINT is the address the manifest targets. Keep it in sync with the in-cluster
+  # CAS (CAS_NAME.CAS_NAMESPACE) so changing the CAS name or namespace does not leave the
+  # manifest pointed at a stale endpoint. Set CAS_ENDPOINT explicitly to run against an
+  # external CAS, e.g. edge.scone-cas.cf.
+  if [[ -n "${CAS_ENDPOINT:-}" ]]; then
+    upsert_scalar "$values_file" "CAS_ENDPOINT" "$CAS_ENDPOINT"
+  else
+    eff_cas_name="$(awk -F': ' '/^  CAS_NAME:/ { gsub(/["'\''[:space:]]/, "", $2); print $2; exit }' "$values_file")"
+    eff_cas_namespace="$(awk -F': ' '/^  CAS_NAMESPACE:/ { gsub(/["'\''[:space:]]/, "", $2); print $2; exit }' "$values_file")"
+    if [[ -n "$eff_cas_name" && -n "$eff_cas_namespace" ]]; then
+      upsert_scalar "$values_file" "CAS_ENDPOINT" "${eff_cas_name}.${eff_cas_namespace}"
+    fi
+  fi
+done
+
+# image-signing still uses the flag-style SCONE_ENCLAVE; override the boolean set above.
+for values_file in "${flag_mode_files[@]}"; do
+  upsert_scalar "$values_file" "SCONE_ENCLAVE" "$flag_scone_enclave"
 done
 
 declare -A seen_namespaces=()

--- a/scripts/prepare-example-ci.sh
+++ b/scripts/prepare-example-ci.sh
@@ -185,10 +185,12 @@ if [[ "$mode" == "sgx" ]]; then
   tee_type="sgx"
   scone_enclave="'false'"
   flag_scone_enclave="''"
+  flag_cvm_mode="''"
 else
   tee_type="cvm"
   scone_enclave="'true'"
   flag_scone_enclave="--scone-enclave"
+  flag_cvm_mode="--cvm"
 fi
 
 for values_file in "${all_values_files[@]}"; do
@@ -220,9 +222,12 @@ for values_file in "${all_values_files[@]}"; do
   fi
 done
 
-# image-signing still uses the flag-style SCONE_ENCLAVE; override the boolean set above.
+# image-signing still uses the flag-style SCONE_ENCLAVE and CVM_MODE (it passes --cvm into
+# `scone-td-build register`), so override the boolean/tee-type set above; otherwise the CVM
+# sweep would leave it on the SGX path.
 for values_file in "${flag_mode_files[@]}"; do
   upsert_scalar "$values_file" "SCONE_ENCLAVE" "$flag_scone_enclave"
+  upsert_scalar "$values_file" "CVM_MODE" "$flag_cvm_mode"
 done
 
 declare -A seen_namespaces=()

--- a/scripts/software-updates.sh
+++ b/scripts/software-updates.sh
@@ -133,7 +133,7 @@ rm -f software-updates-demo.json scone.v1.yaml scone.v2.yaml k8s/manifest.v1.yam
 printf "${VIOLET}"
 printf '%s\n' ''
 printf '%s\n' 'Load the full variable set from `environment-variables.md` first, so `NAMESPACE` and'
-printf '%s\n' '`CVM_MODE` are available to derive the CAS session namespace below:'
+printf '%s\n' '`TEE_TYPE` are available to derive the CAS session namespace below:'
 printf '%s\n' ''
 printf "${RESET}"
 
@@ -154,7 +154,7 @@ printf "${RESET}"
 printf "${ORANGE}"
 printf '%s\n' '# Export the required environment variable for the next steps.'
 printf '%s\n' 'export SIGNER="$(scone self show-session-signing-key)"'
-printf '%s\n' '# Fixed per Kubernetes NAMESPACE and CVM_MODE on purpose: CAS sessions are append-only'
+printf '%s\n' '# Fixed per Kubernetes NAMESPACE and TEE_TYPE on purpose: CAS sessions are append-only'
 printf '%s\n' '# (there'\''s no delete operation in the CLI), so a fresh random namespace on every run'
 printf '%s\n' '# would leave a new, never-cleaned-up session behind each time. Reusing the same name'
 printf '%s\n' '# for repeat runs of the *same* NAMESPACE and mode means a rerun updates the existing'
@@ -164,7 +164,7 @@ printf '%s\n' '# property while still isolating different Kubernetes namespaces 
 printf '%s\n' '# different environments) and the SGX vs CVM CI sweeps from sharing one CAS session'
 printf '%s\n' '# and one generated API_PASSWORD.'
 printf '%s\n' 'mode_suffix="sgx"'
-printf '%s\n' 'if [ "${CVM_MODE}" = "true" ]; then'
+printf '%s\n' 'if [ "${TEE_TYPE}" = "cvm" ]; then'
 printf '%s\n' '  mode_suffix="cvm"'
 printf '%s\n' 'fi'
 printf '%s\n' 'export SESSION_NAMESPACE="software-update-demo-${NAMESPACE}-${mode_suffix}"'
@@ -174,7 +174,7 @@ printf "${RESET}"
 
 # Export the required environment variable for the next steps.
 export SIGNER="$(scone self show-session-signing-key)"
-# Fixed per Kubernetes NAMESPACE and CVM_MODE on purpose: CAS sessions are append-only
+# Fixed per Kubernetes NAMESPACE and TEE_TYPE on purpose: CAS sessions are append-only
 # (there's no delete operation in the CLI), so a fresh random namespace on every run
 # would leave a new, never-cleaned-up session behind each time. Reusing the same name
 # for repeat runs of the *same* NAMESPACE and mode means a rerun updates the existing
@@ -184,7 +184,7 @@ export SIGNER="$(scone self show-session-signing-key)"
 # different environments) and the SGX vs CVM CI sweeps from sharing one CAS session
 # and one generated API_PASSWORD.
 mode_suffix="sgx"
-if [ "${CVM_MODE}" = "true" ]; then
+if [ "${TEE_TYPE}" = "cvm" ]; then
   mode_suffix="cvm"
 fi
 export SESSION_NAMESPACE="software-update-demo-${NAMESPACE}-${mode_suffix}"
@@ -359,13 +359,13 @@ printf "${ORANGE}"
 printf '%s\n' '# Remove any existing state file.'
 printf '%s\n' 'rm -f software-updates-demo.json || true'
 printf '%s\n' '# Generate the confidential image and sanitized manifest from the SCONE configuration.'
-printf '%s\n' 'scone-td-build from -y scone.v1.yaml'
+printf '%s\n' 'scone-td-build apply -f scone.v1.yaml'
 printf "${RESET}"
 
 # Remove any existing state file.
 rm -f software-updates-demo.json || true
 # Generate the confidential image and sanitized manifest from the SCONE configuration.
-scone-td-build from -y scone.v1.yaml
+scone-td-build apply -f scone.v1.yaml
 
 printf "${VIOLET}"
 printf '%s\n' ''
@@ -455,11 +455,11 @@ printf "${RESET}"
 
 printf "${ORANGE}"
 printf '%s\n' '# Generate the confidential image and sanitized manifest from the SCONE configuration.'
-printf '%s\n' 'scone-td-build from -y scone.v2.yaml'
+printf '%s\n' 'scone-td-build apply -f scone.v2.yaml'
 printf "${RESET}"
 
 # Generate the confidential image and sanitized manifest from the SCONE configuration.
-scone-td-build from -y scone.v2.yaml
+scone-td-build apply -f scone.v2.yaml
 
 printf "${VIOLET}"
 printf '%s\n' ''
@@ -597,7 +597,7 @@ printf '%s\n' 'This does not, and cannot, delete the CAS-side session under `${S
 printf '%s\n' 'sessions are append-only and the `scone` CLI has no session-delete operation, by design,'
 printf '%s\n' 'so the audit trail of every update stays intact. Since `${SESSION_NAMESPACE}` is fixed'
 printf '%s\n' 'per `NAMESPACE`/mode (see Step 1), re-running this demo later with the same `NAMESPACE`'
-printf '%s\n' 'and `CVM_MODE` updates that same session in place instead of leaving a new one behind, so'
+printf '%s\n' 'and `TEE_TYPE` updates that same session in place instead of leaving a new one behind, so'
 printf '%s\n' 'there'\''s no unbounded buildup of sessions or generated `API_PASSWORD` values across runs.'
 printf '%s\n' 'Different namespaces or modes (including the SGX and CVM CI sweeps) each get their own'
 printf '%s\n' 'isolated session instead of sharing one.'

--- a/scripts/web-server.sh
+++ b/scripts/web-server.sh
@@ -152,8 +152,9 @@ printf '%s\n' '- `$IMAGE_PULL_SECRET_NAME` - Pull secret name (default: `sconeap
 printf '%s\n' '- `$SCONE_RUNTIME_VERSION` - SCONE version to use (for example, `6.1.0-rc.0`)'
 printf '%s\n' '- `$CAS_NAMESPACE` - CAS namespace (for example, `default`)'
 printf '%s\n' '- `$CAS_NAME` - CAS name (for example, `cas`)'
-printf '%s\n' '- `$CVM_MODE` - Set to `--cvm` for CVM mode, otherwise leave empty for SGX'
-printf '%s\n' '- `$SCONE_ENCLAVE` - In CVM mode, set to `--scone-enclave` for confidential nodes, or leave empty for Kata Pods'
+printf '%s\n' '- `$CAS_ENDPOINT` - Address the manifest targets; keep it in sync with `$CAS_NAME`.`$CAS_NAMESPACE` (default: `cas.default`), or set to an external CAS address to run against one'
+printf '%s\n' '- `$TEE_TYPE` - Set to `cvm` for CVM mode or `sgx` for SGX'
+printf '%s\n' '- `$SCONE_ENCLAVE` - In CVM mode, set to `true` for confidential nodes, or `false` for Kata Pods'
 printf '%s\n' '- `$NAMESPACE` - Kubernetes namespace where the demo runs (default: `default`)'
 printf '%s\n' ''
 printf "${RESET}"
@@ -182,21 +183,23 @@ kubectl create namespace ${NAMESPACE} --dry-run=client -o yaml | kubectl apply -
 
 printf "${VIOLET}"
 printf '%s\n' ''
-printf '%s\n' 'Attest CAS before sending encrypted policies. The kubectl path covers in-cluster CAS; if it fails (typical when `${CAS_NAME}.${CAS_NAMESPACE}` resolves to an external CAS like `scone-cas.cf`), the second branch attests the public CAS directly.'
+printf '%s\n' 'Attest CAS before sending encrypted policies. The kubectl path covers in-cluster CAS; if it fails (typical when `${CAS_ENDPOINT}` points at an external CAS like `edge.scone-cas.cf`), the second branch attests the public CAS directly.'
 printf '%s\n' ''
 printf "${RESET}"
 
 printf "${ORANGE}"
 printf '%s\n' '# Attest the CAS instance before sending encrypted policies.'
 printf '%s\n' 'kubectl scone cas attest --namespace ${CAS_NAMESPACE} ${CAS_NAME} -C -G -S \'
-printf '%s\n' '    || scone cas attest ${CAS_NAME}.${CAS_NAMESPACE} -C -G -S \'
-printf '%s\n' '        --only_for_testing-debug --only_for_testing-ignore-signer --only_for_testing-trust-any'
+printf '%s\n' '    || scone cas attest ${CAS_ENDPOINT} -C -G -S \'
+printf '%s\n' '        --only_for_testing-debug --only_for_testing-ignore-signer --only_for_testing-trust-any \'
+printf '%s\n' '    || echo "CAS attestation skipped: ${CAS_ENDPOINT} runs in simulation mode, so it cannot produce a DCAP quote"'
 printf "${RESET}"
 
 # Attest the CAS instance before sending encrypted policies.
 kubectl scone cas attest --namespace ${CAS_NAMESPACE} ${CAS_NAME} -C -G -S \
-    || scone cas attest ${CAS_NAME}.${CAS_NAMESPACE} -C -G -S \
-        --only_for_testing-debug --only_for_testing-ignore-signer --only_for_testing-trust-any
+    || scone cas attest ${CAS_ENDPOINT} -C -G -S \
+        --only_for_testing-debug --only_for_testing-ignore-signer --only_for_testing-trust-any \
+    || echo "CAS attestation skipped: ${CAS_ENDPOINT} runs in simulation mode, so it cannot produce a DCAP quote"
 
 printf "${VIOLET}"
 printf '%s\n' ''
@@ -209,10 +212,14 @@ printf "${RESET}"
 printf "${ORANGE}"
 printf '%s\n' '# Render the template with the selected values.'
 printf '%s\n' 'tplenv --file manifest.template.yaml --create-values-file --output manifest.yaml'
+printf '%s\n' '# Render the SCONE manifest that drives register plus apply.'
+printf '%s\n' 'tplenv --file scone.template.yaml --create-values-file --output scone.yaml --indent'
 printf "${RESET}"
 
 # Render the template with the selected values.
 tplenv --file manifest.template.yaml --create-values-file --output manifest.yaml
+# Render the SCONE manifest that drives register plus apply.
+tplenv --file scone.template.yaml --create-values-file --output scone.yaml --indent
 
 printf "${VIOLET}"
 printf '%s\n' ''
@@ -296,35 +303,8 @@ fi
 
 printf "${VIOLET}"
 printf '%s\n' ''
-printf '%s\n' 'Register the image with `scone-td-build`:'
-printf '%s\n' ''
-printf "${RESET}"
-
-printf "${ORANGE}"
-printf '%s\n' '# Register the image for confidential execution.'
-printf '%s\n' 'scone-td-build register \'
-printf '%s\n' '  --protected-image ${IMAGE_NAME} \'
-printf '%s\n' '  --unprotected-image ${IMAGE_NAME} \'
-printf '%s\n' '  --destination-image ${DESTINATION_IMAGE_NAME} \'
-printf '%s\n' '  --push \'
-printf '%s\n' '  -s ./storage.json \'
-printf '%s\n' '  --enforce /app/web-server \'
-printf '%s\n' '  --version ${SCONE_RUNTIME_VERSION} \'
-printf '%s\n' '  ${CVM_MODE}'
-printf "${RESET}"
-
-# Register the image for confidential execution.
-scone-td-build register \
-  --protected-image ${IMAGE_NAME} \
-  --unprotected-image ${IMAGE_NAME} \
-  --destination-image ${DESTINATION_IMAGE_NAME} \
-  --push \
-  -s ./storage.json \
-  --enforce /app/web-server \
-  --version ${SCONE_RUNTIME_VERSION} \
-  ${CVM_MODE}
-
-printf "${VIOLET}"
+printf '%s\n' '`scone.yaml` declares the `Register` for this image and the `Apply` that transforms the'
+printf '%s\n' 'manifest, so both run from a single command in the conversion step below.'
 printf '%s\n' ''
 printf '%s\n' '## 6. Test the Native Manifest (Optional)'
 printf '%s\n' ''
@@ -368,7 +348,7 @@ printf '%s\n' 'while true; do kubectl port-forward deployment/web-server 8000:80
 printf '%s\n' 'set +m'
 printf '%s\n' ''
 printf '%s\n' '# Retry the wrapped command until it succeeds or reaches the retry limit.'
-printf '%s\n' 'retry-spinner -- curl http://localhost:8000/env/MY_POD_IP'
+printf '%s\n' 'retry-spinner --retries 40 --wait 10 -- curl http://localhost:8000/env/MY_POD_IP'
 printf '%s\n' '# Run the demo test script.'
 printf '%s\n' './test.sh'
 printf '%s\n' ''
@@ -395,7 +375,7 @@ while true; do kubectl port-forward deployment/web-server 8000:8000 -n ${NAMESPA
 set +m
 
 # Retry the wrapped command until it succeeds or reaches the retry limit.
-retry-spinner -- curl http://localhost:8000/env/MY_POD_IP
+retry-spinner --retries 40 --wait 10 -- curl http://localhost:8000/env/MY_POD_IP
 # Run the demo test script.
 ./test.sh
 
@@ -417,36 +397,12 @@ printf '%s\n' ''
 printf "${RESET}"
 
 printf "${ORANGE}"
-printf '%s\n' '# Convert the native manifest into a confidential manifest.'
-printf '%s\n' 'scone-td-build apply \'
-printf '%s\n' '  -f manifest.yaml \'
-printf '%s\n' '  -c ${CAS_NAME}.${CAS_NAMESPACE} \'
-printf '%s\n' '  -s ./storage.json \'
-printf '%s\n' '  --spol \'
-printf '%s\n' '  --manifest-env SCONE_SYSLIBS=1 \'
-printf '%s\n' '  --manifest-env SCONE_PRODUCTION=0 \'
-printf '%s\n' '  --manifest-env SCONE_VERSION=1 \'
-printf '%s\n' '  --manifest-env SCONE_HEAP=2G \'
-printf '%s\n' '  --session-env SCONE_VERSION=1 \'
-printf '%s\n' '  --output-manifest-file manifest.sanitized.yaml \'
-printf '%s\n' '  --version ${SCONE_RUNTIME_VERSION} -p \'
-printf '%s\n' '  ${CVM_MODE} ${SCONE_ENCLAVE}'
+printf '%s\n' '# Register the image and transform the manifest in one step.'
+printf '%s\n' 'scone-td-build apply -f scone.yaml'
 printf "${RESET}"
 
-# Convert the native manifest into a confidential manifest.
-scone-td-build apply \
-  -f manifest.yaml \
-  -c ${CAS_NAME}.${CAS_NAMESPACE} \
-  -s ./storage.json \
-  --spol \
-  --manifest-env SCONE_SYSLIBS=1 \
-  --manifest-env SCONE_PRODUCTION=0 \
-  --manifest-env SCONE_VERSION=1 \
-  --manifest-env SCONE_HEAP=2G \
-  --session-env SCONE_VERSION=1 \
-  --output-manifest-file manifest.sanitized.yaml \
-  --version ${SCONE_RUNTIME_VERSION} -p \
-  ${CVM_MODE} ${SCONE_ENCLAVE}
+# Register the image and transform the manifest in one step.
+scone-td-build apply -f scone.yaml
 
 printf "${VIOLET}"
 printf '%s\n' ''

--- a/software-updates/README.md
+++ b/software-updates/README.md
@@ -53,7 +53,7 @@ rm -f software-updates-demo.json scone.v1.yaml scone.v2.yaml k8s/manifest.v1.yam
 ```
 
 Load the full variable set from `environment-variables.md` first, so `NAMESPACE` and
-`CVM_MODE` are available to derive the CAS session namespace below:
+`TEE_TYPE` are available to derive the CAS session namespace below:
 
 ```bash
 # Load environment variables from the tplenv definition file.
@@ -65,7 +65,7 @@ Set `SIGNER` for policy signing and the CAS session namespace shared by both v1 
 ```bash
 # Export the required environment variable for the next steps.
 export SIGNER="$(scone self show-session-signing-key)"
-# Fixed per Kubernetes NAMESPACE and CVM_MODE on purpose: CAS sessions are append-only
+# Fixed per Kubernetes NAMESPACE and TEE_TYPE on purpose: CAS sessions are append-only
 # (there's no delete operation in the CLI), so a fresh random namespace on every run
 # would leave a new, never-cleaned-up session behind each time. Reusing the same name
 # for repeat runs of the *same* NAMESPACE and mode means a rerun updates the existing
@@ -75,7 +75,7 @@ export SIGNER="$(scone self show-session-signing-key)"
 # different environments) and the SGX vs CVM CI sweeps from sharing one CAS session
 # and one generated API_PASSWORD.
 mode_suffix="sgx"
-if [ "${CVM_MODE}" = "true" ]; then
+if [ "${TEE_TYPE}" = "cvm" ]; then
   mode_suffix="cvm"
 fi
 export SESSION_NAMESPACE="software-update-demo-${NAMESPACE}-${mode_suffix}"
@@ -182,7 +182,7 @@ fi
 # Remove any existing state file.
 rm -f software-updates-demo.json || true
 # Generate the confidential image and sanitized manifest from the SCONE configuration.
-scone-td-build from -y scone.v1.yaml
+scone-td-build apply -f scone.v1.yaml
 ```
 
 This command:
@@ -241,7 +241,7 @@ Running Version 1. Update by applying the v2 confidential manifest.
 
 ```bash
 # Generate the confidential image and sanitized manifest from the SCONE configuration.
-scone-td-build from -y scone.v2.yaml
+scone-td-build apply -f scone.v2.yaml
 ```
 
 This command:
@@ -326,7 +326,7 @@ This does not, and cannot, delete the CAS-side session under `${SESSION_NAMESPAC
 sessions are append-only and the `scone` CLI has no session-delete operation, by design,
 so the audit trail of every update stays intact. Since `${SESSION_NAMESPACE}` is fixed
 per `NAMESPACE`/mode (see Step 1), re-running this demo later with the same `NAMESPACE`
-and `CVM_MODE` updates that same session in place instead of leaving a new one behind, so
+and `TEE_TYPE` updates that same session in place instead of leaving a new one behind, so
 there's no unbounded buildup of sessions or generated `API_PASSWORD` values across runs.
 Different namespaces or modes (including the SGX and CVM CI sweeps) each get their own
 isolated session instead of sharing one.

--- a/software-updates/Values.yaml
+++ b/software-updates/Values.yaml
@@ -8,7 +8,8 @@ environment:
   SCONE_RUNTIME_VERSION: 6.1.0-rc.0
   CAS_NAMESPACE: default
   CAS_NAME: cas
-  CVM_MODE: 'false'
+  CAS_ENDPOINT: cas.default
+  TEE_TYPE: sgx
   SCONE_ENCLAVE: 'false'
   NAMESPACE: default
   API_USER: myself

--- a/software-updates/environment-variables.md
+++ b/software-updates/environment-variables.md
@@ -6,14 +6,17 @@ This file defines the environment variables used to configure the `software-upda
 4. The confidential version 2 image URL is stored in `${DESTINATION_IMAGE_NAME_V2}`.
 5. The Kubernetes namespace where the demo manifests are deployed is stored in `${NAMESPACE}`.
    The default value is `default`. The CAS session namespace `SESSION_NAMESPACE` (set in
-   Step 1 of `README.md`) is derived from `${NAMESPACE}` and `${CVM_MODE}`, so different
+   Step 1 of `README.md`) is derived from `${NAMESPACE}` and `${TEE_TYPE}`, so different
    namespaces or modes never share the same CAS session. It is not collected here.
 6. The name of the pull secret for both the native and confidential container images is stored in `${IMAGE_PULL_SECRET_NAME}`.
 7. The SCONE version is stored in `${SCONE_RUNTIME_VERSION}`.
    The recommended value is `6.1.0-rc.0`.
 8. The CAS runs in Kubernetes namespace `${CAS_NAMESPACE}`.
 9. The CAS name is stored in `${CAS_NAME}`.
-10. If you want to use CVM mode, set `${CVM_MODE}` to `true`. For SGX, set to `false`.
+   `${CAS_NAME}` and `${CAS_NAMESPACE}` address the in-cluster CAS for `kubectl` calls.
+   The manifests use `${CAS_ENDPOINT}` instead, which defaults to `cas.default`. Point it at
+   a public CAS to run against one, for example `CAS_ENDPOINT=edge.scone-cas.cf`.
+10. Set `${TEE_TYPE}` to `cvm` for CVM mode or `sgx` for SGX.
 11. In CVM mode, you can run on confidential Kubernetes nodes or Kata Pods.
     We recommend using confidential nodes and setting `${SCONE_ENCLAVE}` to `true`.
 12. The local signer key `SIGNER` is set automatically in Step 1 of `README.md` from the

--- a/software-updates/scone.v1.template.yaml
+++ b/software-updates/scone.v1.template.yaml
@@ -3,14 +3,14 @@ kind: Register
 metadata:
   name: software-updates-demo
 spec:
-  protected_image: ${IMAGE_NAME_V1}
-  unprotected_image: ${IMAGE_NAME_V1}
-  destination_image: ${DESTINATION_IMAGE_NAME_V1}
-  enforce: ["/usr/local/bin/python3"]
-  push_scone_image: true
-  version: ${SCONE_RUNTIME_VERSION}
-  cvm: ${CVM_MODE}
-  manifest_env:
+  source-image: ${IMAGE_NAME_V1}
+  reference-image: ${IMAGE_NAME_V1}
+  output-image: ${DESTINATION_IMAGE_NAME_V1}
+  protected-binaries: ["/usr/local/bin/python3"]
+  push-image: true
+  scone-version: ${SCONE_RUNTIME_VERSION}
+  tee-type: ${TEE_TYPE}
+  container-env:
     - {name: SCONE_VERSION, value: "1"}
     - {name: SCONE_SYSLIBS, value: "1"}
     - {name: SCONE_PRODUCTION, value: "0"}
@@ -26,20 +26,20 @@ spec:
   file:
     - "k8s/scone-secret.yaml"
     - "k8s/manifest.v1.yaml"
-  output_manifest_file: "manifest.prod.sanitized.yaml"
-  output_session_file: "manifest.prod.session.yaml"
-  cas_address:
-    address: ${CAS_NAME}.${CAS_NAMESPACE}
-  session_env:
+  output-manifest: "manifest.prod.sanitized.yaml"
+  output-session: "manifest.prod.session.yaml"
+  cas-endpoint:
+    address: ${CAS_ENDPOINT}
+  cas-policy-env:
     - {name: SCONE_VERSION, value: "1"}
-  manifest_env:
+  container-env:
     - {name: SCONE_VERSION, value: "1"}
     - {name: SCONE_SYSLIBS, value: "1"}
     - {name: SCONE_PRODUCTION, value: "0"}
     - {name: SCONE_HEAP, value: "760M"}
     - {name: SCONE_ALLOW_DLOPEN, value: "2"}
-  version: ${SCONE_RUNTIME_VERSION}
+  scone-version: ${SCONE_RUNTIME_VERSION}
   permissive: true
-  spol: true
-  cvm: ${CVM_MODE}
-  scone_enclave: ${SCONE_ENCLAVE}
+  encrypted-cas-policy: false
+  tee-type: ${TEE_TYPE}
+  scone-enclave: ${SCONE_ENCLAVE}

--- a/software-updates/scone.v2.template.yaml
+++ b/software-updates/scone.v2.template.yaml
@@ -3,14 +3,14 @@ kind: Register
 metadata:
   name: software-updates-demo
 spec:
-  protected_image: ${IMAGE_NAME_V2}
-  unprotected_image: ${IMAGE_NAME_V2}
-  destination_image: ${DESTINATION_IMAGE_NAME_V2}
-  enforce: ["/usr/local/bin/python3"]
-  push_scone_image: true
-  version: ${SCONE_RUNTIME_VERSION}
-  cvm: ${CVM_MODE}
-  manifest_env:
+  source-image: ${IMAGE_NAME_V2}
+  reference-image: ${IMAGE_NAME_V2}
+  output-image: ${DESTINATION_IMAGE_NAME_V2}
+  protected-binaries: ["/usr/local/bin/python3"]
+  push-image: true
+  scone-version: ${SCONE_RUNTIME_VERSION}
+  tee-type: ${TEE_TYPE}
+  container-env:
     - {name: SCONE_VERSION, value: "1"}
     - {name: SCONE_SYSLIBS, value: "1"}
     - {name: SCONE_PRODUCTION, value: "0"}
@@ -26,20 +26,20 @@ spec:
   file:
     - "k8s/scone-secret.yaml"
     - "k8s/manifest.v2.yaml"
-  output_manifest_file: "manifest.prod.sanitized.yaml"
-  output_session_file: "manifest.prod.session.yaml"
-  cas_address:
-    address: ${CAS_NAME}.${CAS_NAMESPACE}
-  session_env:
+  output-manifest: "manifest.prod.sanitized.yaml"
+  output-session: "manifest.prod.session.yaml"
+  cas-endpoint:
+    address: ${CAS_ENDPOINT}
+  cas-policy-env:
     - {name: SCONE_VERSION, value: "1"}
-  manifest_env:
+  container-env:
     - {name: SCONE_VERSION, value: "1"}
     - {name: SCONE_SYSLIBS, value: "1"}
     - {name: SCONE_PRODUCTION, value: "0"}
     - {name: SCONE_HEAP, value: "760M"}
     - {name: SCONE_ALLOW_DLOPEN, value: "2"}
-  version: ${SCONE_RUNTIME_VERSION}
+  scone-version: ${SCONE_RUNTIME_VERSION}
   permissive: true
-  spol: true
-  cvm: ${CVM_MODE}
-  scone_enclave: ${SCONE_ENCLAVE}
+  encrypted-cas-policy: false
+  tee-type: ${TEE_TYPE}
+  scone-enclave: ${SCONE_ENCLAVE}

--- a/web-server/README.md
+++ b/web-server/README.md
@@ -70,8 +70,9 @@ Defaults are stored in `Values.yaml`. `tplenv` asks whether to keep them and set
 - `$SCONE_RUNTIME_VERSION` - SCONE version to use (for example, `6.1.0-rc.0`)
 - `$CAS_NAMESPACE` - CAS namespace (for example, `default`)
 - `$CAS_NAME` - CAS name (for example, `cas`)
-- `$CVM_MODE` - Set to `--cvm` for CVM mode, otherwise leave empty for SGX
-- `$SCONE_ENCLAVE` - In CVM mode, set to `--scone-enclave` for confidential nodes, or leave empty for Kata Pods
+- `$CAS_ENDPOINT` - Address the manifest targets; keep it in sync with `$CAS_NAME`.`$CAS_NAMESPACE` (default: `cas.default`), or set to an external CAS address to run against one
+- `$TEE_TYPE` - Set to `cvm` for CVM mode or `sgx` for SGX
+- `$SCONE_ENCLAVE` - In CVM mode, set to `true` for confidential nodes, or `false` for Kata Pods
 - `$NAMESPACE` - Kubernetes namespace where the demo runs (default: `default`)
 
 ```bash
@@ -86,13 +87,14 @@ Create the demo namespace if it does not already exist:
 kubectl create namespace ${NAMESPACE} --dry-run=client -o yaml | kubectl apply -f - 2> /dev/null || echo "Patching namespace ${NAMESPACE} failed -- ignoring this"
 ```
 
-Attest CAS before sending encrypted policies. The kubectl path covers in-cluster CAS; if it fails (typical when `${CAS_NAME}.${CAS_NAMESPACE}` resolves to an external CAS like `scone-cas.cf`), the second branch attests the public CAS directly.
+Attest CAS before sending encrypted policies. The kubectl path covers in-cluster CAS; if it fails (typical when `${CAS_ENDPOINT}` points at an external CAS like `edge.scone-cas.cf`), the second branch attests the public CAS directly.
 
 ```bash
 # Attest the CAS instance before sending encrypted policies.
 kubectl scone cas attest --namespace ${CAS_NAMESPACE} ${CAS_NAME} -C -G -S \
-    || scone cas attest ${CAS_NAME}.${CAS_NAMESPACE} -C -G -S \
-        --only_for_testing-debug --only_for_testing-ignore-signer --only_for_testing-trust-any
+    || scone cas attest ${CAS_ENDPOINT} -C -G -S \
+        --only_for_testing-debug --only_for_testing-ignore-signer --only_for_testing-trust-any \
+    || echo "CAS attestation skipped: ${CAS_ENDPOINT} runs in simulation mode, so it cannot produce a DCAP quote"
 ```
 
 If attestation fails, review the output for detected issues and suggested tolerance flags.
@@ -102,6 +104,8 @@ Render the manifest template:
 ```bash
 # Render the template with the selected values.
 tplenv --file manifest.template.yaml --create-values-file --output manifest.yaml
+# Render the SCONE manifest that drives register plus apply.
+tplenv --file scone.template.yaml --create-values-file --output scone.yaml --indent
 ```
 
 ## 4. Create a Pull Secret
@@ -148,20 +152,8 @@ else
 fi
 ```
 
-Register the image with `scone-td-build`:
-
-```bash
-# Register the image for confidential execution.
-scone-td-build register \
-  --protected-image ${IMAGE_NAME} \
-  --unprotected-image ${IMAGE_NAME} \
-  --destination-image ${DESTINATION_IMAGE_NAME} \
-  --push \
-  -s ./storage.json \
-  --enforce /app/web-server \
-  --version ${SCONE_RUNTIME_VERSION} \
-  ${CVM_MODE}
-```
+`scone.yaml` declares the `Register` for this image and the `Apply` that transforms the
+manifest, so both run from a single command in the conversion step below.
 
 ## 6. Test the Native Manifest (Optional)
 
@@ -192,7 +184,7 @@ while true; do kubectl port-forward deployment/web-server 8000:8000 -n ${NAMESPA
 set +m
 
 # Retry the wrapped command until it succeeds or reaches the retry limit.
-retry-spinner -- curl http://localhost:8000/env/MY_POD_IP
+retry-spinner --retries 40 --wait 10 -- curl http://localhost:8000/env/MY_POD_IP
 # Run the demo test script.
 ./test.sh
 
@@ -211,20 +203,8 @@ rm /tmp/pf-8000.pid
 If you want to inspect registration details, see [register-image](https://github.com/scontain/k8s-scone/blob/main/register-image.md).
 
 ```bash
-# Convert the native manifest into a confidential manifest.
-scone-td-build apply \
-  -f manifest.yaml \
-  -c ${CAS_NAME}.${CAS_NAMESPACE} \
-  -s ./storage.json \
-  --spol \
-  --manifest-env SCONE_SYSLIBS=1 \
-  --manifest-env SCONE_PRODUCTION=0 \
-  --manifest-env SCONE_VERSION=1 \
-  --manifest-env SCONE_HEAP=2G \
-  --session-env SCONE_VERSION=1 \
-  --output-manifest-file manifest.sanitized.yaml \
-  --version ${SCONE_RUNTIME_VERSION} -p \
-  ${CVM_MODE} ${SCONE_ENCLAVE}
+# Register the image and transform the manifest in one step.
+scone-td-build apply -f scone.yaml
 ```
 
 ## 8. Deploy the Confidential Manifest

--- a/web-server/Values.yaml
+++ b/web-server/Values.yaml
@@ -3,9 +3,10 @@ environment:
   IMAGE_PULL_SECRET_NAME: sconeapps
   CAS_NAMESPACE: default
   CAS_NAME: cas
-  DESTINATION_IMAGE_NAME: registry.scontain.com/workshop/web-server:protected
+  CAS_ENDPOINT: cas.default
+  DESTINATION_IMAGE_NAME: registry.scontain.com/k8s-scone-images/web-server:protected
   SCONE_RUNTIME_VERSION: 6.1.0-rc.0
-  CVM_MODE: ''
-  SCONE_ENCLAVE: ''
+  TEE_TYPE: sgx
+  SCONE_ENCLAVE: 'false'
   REGISTRY: registry.scontain.com
   NAMESPACE: default

--- a/web-server/environment-variables.md
+++ b/web-server/environment-variables.md
@@ -7,11 +7,12 @@ This file defines the environment variables used to configure this `web-server` 
 4. The SCONE version is stored in `${SCONE_RUNTIME_VERSION}`.
    The current value is `6.1.0-rc.0`.
 5. The CAS runs in Kubernetes namespace `${CAS_NAMESPACE}`.
-   The templates resolve `${CAS_NAME}.${CAS_NAMESPACE}` to the CAS endpoint, so for SCONE's public CAS at `scone-cas.cf` set `CAS_NAMESPACE=cf`.
+   `${CAS_NAME}` and `${CAS_NAMESPACE}` address the in-cluster CAS for `kubectl` calls.
 6. The CAS name is stored in `${CAS_NAME}`.
-   For SCONE's public CAS, set `CAS_NAME=scone-cas`.
-7. If you want to use CVM mode, set `${CVM_MODE}` to `--cvm`. For SGX, leave it empty.
+   The manifests use `${CAS_ENDPOINT}` instead, which defaults to `cas.default`. Point it at
+   a public CAS to run against one, for example `CAS_ENDPOINT=edge.scone-cas.cf`.
+7. Set `${TEE_TYPE}` to `cvm` for CVM mode or `sgx` for SGX.
 8. In CVM mode, you can run on confidential Kubernetes nodes or Kata Pods.
-   We recommend using confidential nodes and setting `${SCONE_ENCLAVE}` to `--scone-enclave`.
+   We recommend using confidential nodes and setting `${SCONE_ENCLAVE}` to `true`.
 9. The Kubernetes namespace where the demo manifests are deployed is stored in `${NAMESPACE}`.
    The default value is `default`.

--- a/web-server/scone.template.yaml
+++ b/web-server/scone.template.yaml
@@ -1,0 +1,35 @@
+apiVersion: scone.cloud/v1
+kind: Register
+metadata:
+  name: web-server
+spec:
+  source-image: ${IMAGE_NAME}
+  reference-image: ${IMAGE_NAME}
+  output-image: ${DESTINATION_IMAGE_NAME}
+  push-image: true
+  protected-binaries: ["/app/web-server"]
+  scone-version: ${SCONE_RUNTIME_VERSION}
+  tee-type: ${TEE_TYPE}
+---
+apiVersion: scone.cloud/v1
+kind: Apply
+metadata:
+  name: web-server
+spec:
+  file:
+    - "manifest.yaml"
+  output-manifest: "manifest.sanitized.yaml"
+  cas-endpoint:
+    address: ${CAS_ENDPOINT}
+  container-env:
+    - {name: SCONE_SYSLIBS, value: "1"}
+    - {name: SCONE_PRODUCTION, value: "0"}
+    - {name: SCONE_VERSION, value: "1"}
+    - {name: SCONE_HEAP, value: "2G"}
+  cas-policy-env:
+    - {name: SCONE_VERSION, value: "1"}
+  permissive: true
+  encrypted-cas-policy: false
+  tee-type: ${TEE_TYPE}
+  scone-enclave: ${SCONE_ENCLAVE}
+  scone-version: ${SCONE_RUNTIME_VERSION}


### PR DESCRIPTION
Updates the demos to the renamed `scone-td-build` manifest fields and the single `apply -f` flow, so they keep working with the rename in scontain/scone-td-build#241.

- Rewrites every demo's `scone.template.yaml` to the new kebab-case field names, including the fields that changed shape (`tee-type`, `topology`, `encrypted-cas-policy`).
- Replaces `CVM_MODE` with `TEE_TYPE` and switches `from -y` to `apply -f` across the demos.
- Addresses pre-existing issues found while validating all nine demos end to end in SGX: a committed session signing key, retry budgets too short for cold protected-image pulls, and an ambiguous version check in software-updates.

Meant to merge together with the rename work in scone-td-build.

---

<!-- status write-up (auto) -->
# Current status

Updates every demo to the renamed fields and the single `apply -f` flow: rewrites each `scone.template.yaml` to kebab-case (including the shape-changing `tee-type`/`topology`/`encrypted-cas-policy`), replaces `CVM_MODE` with `TEE_TYPE`, and switches `from -y` to `apply -f`. Also fixes pre-existing issues found validating all nine demos end to end in SGX (a committed session signing key, retry budgets too short for cold protected-image pulls, an ambiguous version check in software-updates). I validated the renamed-field `apply -f scone.yaml` flow against this branch (hello-world → three encrypted sessions). Currently has merge conflicts (mergeStateStatus DIRTY) — needs a rebase. Meant to merge together with the rename (#241); third in the #274 order.

# Steps to completion

- Rebase to clear the merge conflicts (currently DIRTY).
- Get review.
- Merge after #241 (per the #274 order).

# Acceptance criteria

- [x] Every demo's `scone.template.yaml` uses the new kebab-case fields
- [x] `CVM_MODE` → `TEE_TYPE` and `from -y` → `apply -f` across the demos
- [x] Pre-existing demo issues fixed (committed signing key, retry budgets, version check)
- [ ] Rebased to clear the merge conflicts
- [ ] Reviewed and merged (after #241)
