### PR TITLE
fix(software-updates): poll pod logs for the app line, not kubectl's exit code

### DIFF
--- a/docs/software-updates.sh
+++ b/docs/software-updates.sh
@@ -565,7 +565,27 @@ pe "$(cat <<'EOF'
 EOF
 )"
 pe "$(cat <<'EOF'
-v1_log=$(retry-spinner --retries 10 --wait 5 -- kubectl logs -n ${NAMESPACE} deployment/python-hello-user)
+# The SCONE runtime prints its enclave banner several seconds before the Python app's
+EOF
+)"
+pe "$(cat <<'EOF'
+# first line, and `kubectl logs` exits 0 as soon as that banner exists -- so retrying on
+EOF
+)"
+pe "$(cat <<'EOF'
+# its exit code captures the logs before the app has printed anything. Poll for the app's
+EOF
+)"
+pe "$(cat <<'EOF'
+# own checksum line instead.
+EOF
+)"
+pe "$(cat <<'EOF'
+v1_log=""
+EOF
+)"
+pe "$(cat <<'EOF'
+for _ in $(seq 1 30); do v1_log=$(kubectl logs -n ${NAMESPACE} deployment/python-hello-user 2>/dev/null || true); echo "$v1_log" | grep -q "checksum of the original API_PASSWORD" && break; sleep 5; done
 EOF
 )"
 pe "$(cat <<'EOF'
@@ -680,7 +700,19 @@ pe "$(cat <<'EOF'
 EOF
 )"
 pe "$(cat <<'EOF'
-v2_log=$(retry-spinner --retries 10 --wait 5 -- kubectl logs -n ${NAMESPACE} deployment/python-hello-user)
+# Same enclave-banner race as Step 9: poll until the Version 2 app loop is actually
+EOF
+)"
+pe "$(cat <<'EOF'
+# printing, otherwise the "Running Version 2." check below races the enclave start.
+EOF
+)"
+pe "$(cat <<'EOF'
+v2_log=""
+EOF
+)"
+pe "$(cat <<'EOF'
+for _ in $(seq 1 30); do v2_log=$(kubectl logs -n ${NAMESPACE} deployment/python-hello-user 2>/dev/null || true); echo "$v2_log" | grep -q "Running Version 2\." && break; sleep 5; done
 EOF
 )"
 pe "$(cat <<'EOF'

--- a/scripts/software-updates.sh
+++ b/scripts/software-updates.sh
@@ -401,7 +401,12 @@ printf "${ORANGE}"
 printf '%s\n' '# Show the most recent logs and capture the Version 1 API_PASSWORD checksum, so Step 12'
 printf '%s\n' '# can check it against Version 2'\''s automatically instead of relying on a human comparing'
 printf '%s\n' '# two printed checksums by eye.'
-printf '%s\n' 'v1_log=$(retry-spinner --retries 10 --wait 5 -- kubectl logs -n ${NAMESPACE} deployment/python-hello-user)'
+printf '%s\n' '# The SCONE runtime prints its enclave banner several seconds before the Python app'\''s'
+printf '%s\n' '# first line, and `kubectl logs` exits 0 as soon as that banner exists -- so retrying on'
+printf '%s\n' '# its exit code captures the logs before the app has printed anything. Poll for the app'\''s'
+printf '%s\n' '# own checksum line instead.'
+printf '%s\n' 'v1_log=""'
+printf '%s\n' 'for _ in $(seq 1 30); do v1_log=$(kubectl logs -n ${NAMESPACE} deployment/python-hello-user 2>/dev/null || true); echo "$v1_log" | grep -q "checksum of the original API_PASSWORD" && break; sleep 5; done'
 printf '%s\n' 'echo "$v1_log" | tail -10'
 printf '%s\n' 'v1_checksum=$(echo "$v1_log" | grep -m1 "checksum of the original API_PASSWORD" | grep -oE "'\''[^'\'']+'\''" | tr -d "'\''")'
 printf '%s\n' 'if [ -z "$v1_checksum" ]; then'
@@ -414,7 +419,12 @@ printf "${RESET}"
 # Show the most recent logs and capture the Version 1 API_PASSWORD checksum, so Step 12
 # can check it against Version 2's automatically instead of relying on a human comparing
 # two printed checksums by eye.
-v1_log=$(retry-spinner --retries 10 --wait 5 -- kubectl logs -n ${NAMESPACE} deployment/python-hello-user)
+# The SCONE runtime prints its enclave banner several seconds before the Python app's
+# first line, and `kubectl logs` exits 0 as soon as that banner exists -- so retrying on
+# its exit code captures the logs before the app has printed anything. Poll for the app's
+# own checksum line instead.
+v1_log=""
+for _ in $(seq 1 30); do v1_log=$(kubectl logs -n ${NAMESPACE} deployment/python-hello-user 2>/dev/null || true); echo "$v1_log" | grep -q "checksum of the original API_PASSWORD" && break; sleep 5; done
 echo "$v1_log" | tail -10
 v1_checksum=$(echo "$v1_log" | grep -m1 "checksum of the original API_PASSWORD" | grep -oE "'[^']+'" | tr -d "'")
 if [ -z "$v1_checksum" ]; then
@@ -488,7 +498,10 @@ printf '%s\n' '# Show the most recent logs from Version 2 and check its API_PASS
 printf '%s\n' '# Version 1'\''s captured in Step 9. This is the actual cross-version check: each program'
 printf '%s\n' '# only ever compares against its own startup value, so without this the demo would pass'
 printf '%s\n' '# even if CAS had regenerated API_PASSWORD during the update.'
-printf '%s\n' 'v2_log=$(retry-spinner --retries 10 --wait 5 -- kubectl logs -n ${NAMESPACE} deployment/python-hello-user)'
+printf '%s\n' '# Same enclave-banner race as Step 9: poll until the Version 2 app loop is actually'
+printf '%s\n' '# printing, otherwise the "Running Version 2." check below races the enclave start.'
+printf '%s\n' 'v2_log=""'
+printf '%s\n' 'for _ in $(seq 1 30); do v2_log=$(kubectl logs -n ${NAMESPACE} deployment/python-hello-user 2>/dev/null || true); echo "$v2_log" | grep -q "Running Version 2\." && break; sleep 5; done'
 printf '%s\n' 'echo "$v2_log" | tail -10'
 printf '%s\n' '# Prove Version 2 is actually the program running, not just that the checksum matched.'
 printf '%s\n' '# Both programs print an identical checksum line, so a stale Version 1 deployment (or a'
@@ -518,7 +531,10 @@ printf "${RESET}"
 # Version 1's captured in Step 9. This is the actual cross-version check: each program
 # only ever compares against its own startup value, so without this the demo would pass
 # even if CAS had regenerated API_PASSWORD during the update.
-v2_log=$(retry-spinner --retries 10 --wait 5 -- kubectl logs -n ${NAMESPACE} deployment/python-hello-user)
+# Same enclave-banner race as Step 9: poll until the Version 2 app loop is actually
+# printing, otherwise the "Running Version 2." check below races the enclave start.
+v2_log=""
+for _ in $(seq 1 30); do v2_log=$(kubectl logs -n ${NAMESPACE} deployment/python-hello-user 2>/dev/null || true); echo "$v2_log" | grep -q "Running Version 2\." && break; sleep 5; done
 echo "$v2_log" | tail -10
 # Prove Version 2 is actually the program running, not just that the checksum matched.
 # Both programs print an identical checksum line, so a stale Version 1 deployment (or a

--- a/software-updates/README.md
+++ b/software-updates/README.md
@@ -206,7 +206,12 @@ kubectl rollout status deployment/python-hello-user -n ${NAMESPACE} --timeout=30
 # Show the most recent logs and capture the Version 1 API_PASSWORD checksum, so Step 12
 # can check it against Version 2's automatically instead of relying on a human comparing
 # two printed checksums by eye.
-v1_log=$(retry-spinner --retries 10 --wait 5 -- kubectl logs -n ${NAMESPACE} deployment/python-hello-user)
+# The SCONE runtime prints its enclave banner several seconds before the Python app's
+# first line, and `kubectl logs` exits 0 as soon as that banner exists -- so retrying on
+# its exit code captures the logs before the app has printed anything. Poll for the app's
+# own checksum line instead.
+v1_log=""
+for _ in $(seq 1 30); do v1_log=$(kubectl logs -n ${NAMESPACE} deployment/python-hello-user 2>/dev/null || true); echo "$v1_log" | grep -q "checksum of the original API_PASSWORD" && break; sleep 5; done
 echo "$v1_log" | tail -10
 v1_checksum=$(echo "$v1_log" | grep -m1 "checksum of the original API_PASSWORD" | grep -oE "'[^']+'" | tr -d "'")
 if [ -z "$v1_checksum" ]; then
@@ -263,7 +268,10 @@ kubectl rollout status deployment/python-hello-user -n ${NAMESPACE} --timeout=30
 # Version 1's captured in Step 9. This is the actual cross-version check: each program
 # only ever compares against its own startup value, so without this the demo would pass
 # even if CAS had regenerated API_PASSWORD during the update.
-v2_log=$(retry-spinner --retries 10 --wait 5 -- kubectl logs -n ${NAMESPACE} deployment/python-hello-user)
+# Same enclave-banner race as Step 9: poll until the Version 2 app loop is actually
+# printing, otherwise the "Running Version 2." check below races the enclave start.
+v2_log=""
+for _ in $(seq 1 30); do v2_log=$(kubectl logs -n ${NAMESPACE} deployment/python-hello-user 2>/dev/null || true); echo "$v2_log" | grep -q "Running Version 2\." && break; sleep 5; done
 echo "$v2_log" | tail -10
 # Prove Version 2 is actually the program running, not just that the checksum matched.
 # Both programs print an identical checksum line, so a stale Version 1 deployment (or a


### PR DESCRIPTION
## What

Steps 9 and 12 of the software-updates demo captured pod logs with
`retry-spinner -- kubectl logs deployment/python-hello-user`. `retry-spinner`
retries on the wrapped command's exit code, and `kubectl logs` returns 0 as
soon as any log line exists. The SCONE runtime prints its enclave banner
several seconds before the Python app's first line, so the capture succeeds on
the first try with runtime-only output:

- Step 9's `grep` for `checksum of the original API_PASSWORD` finds nothing and exits 1.
- On a slower enclave start, Step 12's `Running Version 2.` marker check races the same way.

The demo passed or failed depending purely on how fast the enclave loaded, which
made it intermittently red in the kubectl-clusterapi SEV-SNP e2e (the enclave
starts in simulated mode there and takes longer than the retry captured).

## Fix

Replace the exit-code retry with a bounded poll (30 x 5s) that waits for the
app's own output before reading the logs -- the checksum line in Step 9, the
`Running Version 2.` marker in Step 12. Kept as a single-line loop so the
`--docs-pe` screencast generator still renders it as one `pe` step.

`software-updates/README.md` is the source; `scripts/software-updates.sh` and
`docs/software-updates.sh` are regenerated via `scripts/extract-bash.sh`.
Both pass `shellcheck` and `bash -n`.